### PR TITLE
Add support for option keywords

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -148,6 +148,29 @@ You are in a red room.
 There is a door and a bell.
 ```
 
+## Formulae
+
+Choices can also have conditions, components, and products.
+The introduction to an option line may include any number of these.
+An expression in braces serves as a condition, without which the option
+is not available.
+
+An expression with the plus `+` prefix denotes a product of the choice.
+Chosing this option increases the variable.
+
+An expression with the minus `-` prefix is a component that gets
+consumed with the option. So, `{-2coal}` would indicate that the option
+would consume two coal, but also indicates that the option is not available
+unless the `coal` variable is at least two.
+
+These primitives enable concise crafting formulae.
+
+```
++ {at==smelter} {bellows} {-coal} {-lyme} {-iron} {+2steel}
+  [You chose[Choose] to work the bellows, to convert coal, lyme, and iron to
+  molten steel. ] The glowing metal emerges from the smelter.
+```
+
 ## Questions and Answers
 
 Options, starting with plus or asterisk, have a special notation and use the
@@ -220,6 +243,42 @@ it will fall through and automatically follow the first collected non-option.
 >
 ->start
 ```
+
+## Keywords
+
+Options can also have keywords. Any term in angle brackets, ``<term>``, denotes
+a keyword name for an option.  With the command line (readline) engine, options
+can be chosen by number or keyword.
+
+```
++ <apple> [You chose[Choose] apple. ]
++ <orange> <lemon> [You chose[Choose] orange or lemon. ]
+```
+
+```
+1.  Choose apple.
+2.  Choose orange or lemon.
+> lemon
+
+You chose orange or lemon.
+```
+
+Invisible options can also be chosen by keyword.
+
+```
++ <apple> [You chose[Choose] apple. ]
++ <orange> <lemon> [You chose[Choose] orange or lemon. ]
++ <grape> [] You chose a grape, which wasn'}t even on the menu.
+```
+
+```
+1.  Choose apple.
+2.  Choose orange or lemon.
+> grape
+
+You chose a grape, which wasn’t even on the menu.
+```
+
 
 # Directives
 

--- a/engine-test.js
+++ b/engine-test.js
@@ -34,6 +34,9 @@ function main() {
     test('tests/gradient.kni', 'tests/gradient.1');
     test('tests/indirect.kni', 'tests/indirect.1');
     test('tests/jump-and-ask.kni', 'tests/jump-and-ask.1');
+    test('tests/keywords.kni', 'tests/keywords.1');
+    test('tests/keywords.kni', 'tests/keywords.2');
+    test('tests/keywords.kni', 'tests/keywords.3');
     test('tests/literals.kni', 'tests/literals.1');
     test('tests/loop.kni', 'tests/loop.1');
     test('tests/math.kni', 'tests/math.1');

--- a/story.js
+++ b/story.js
@@ -61,6 +61,7 @@ function Option(label) {
     this.type = 'opt';
     this.question = [];
     this.answer = [];
+    this.keywords = null;
     this.next = null;
     this.position = null;
     Object.seal(this);

--- a/tests/keywords.1
+++ b/tests/keywords.1
@@ -1,0 +1,6 @@
+1.  Choose apple.
+2.  Choose orange or lemon.
+> lemon
+
+You chose orange or lemon.
+

--- a/tests/keywords.2
+++ b/tests/keywords.2
@@ -1,0 +1,6 @@
+1.  Choose apple.
+2.  Choose orange or lemon.
+> apple
+
+You chose apple.
+

--- a/tests/keywords.3
+++ b/tests/keywords.3
@@ -1,0 +1,6 @@
+1.  Choose apple.
+2.  Choose orange or lemon.
+> grape
+
+You chose a grape, which wasn’t even on the menu.
+

--- a/tests/keywords.kni
+++ b/tests/keywords.kni
@@ -1,0 +1,4 @@
++ <apple> [You chose[Choose] apple. ]
++ <orange> <lemon> [You chose[Choose] orange or lemon. ]
++ <grape> [] You chose a grape, which wasn'}t even on the menu.
+>


### PR DESCRIPTION
This adds support for keyword options to the Kni grammar and command line engine. This doesn’t fully enable parser fiction, but will be handy to make it possible to write more stable tests (choices denoted by keyword, assertions by capturing and testing variables).

I’ve written this feature so that I’ll eventually be able to drive choices by associating icons with keywords. Icons associated with a choice will be highlighted when they correspond to an option, and clicking such an icon will emit the corresponding keyword.