### PR TITLE
Support subroutine options

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,4 +1,22 @@
 
+# v3.0.0
+
+This version allows options to be declared in subroutines.
+
+This major version breaks compatibility with previous JSON state machines.
+The new state machine has reserved "RET" and "ESC" labels, instead of
+using null to mean "return". The "escape" label is new, and causes a
+function to return through a call "branch" when it returns, instead of
+following to the "next" of the call site.
+
+This major version also breaks compatibility with previous JSON interactive
+story state objects.  These have a new format that is almost fully
+desymbolicated, which makes them more brittle to story changes but makes the
+URL anchor for HTML stories more compact.
+
+The command line mode now supports "back" and diagnostic commands "capture" and
+"replay".
+
 # v2.2.2
 
 - Fix command line usage by upgrading the command line argument parser, SHON.

--- a/describe.js
+++ b/describe.js
@@ -25,10 +25,10 @@ types.goto = function goto(node) {
 };
 
 types.call = function call(node) {
-    return node.branch + '(' + node.args.map(S).join(' ') + ')';
+    return node.label + '(' + node.args.map(S).join(' ') + ') esc ' + node.branch;
 };
 
-types.args = function args(node) {
+types.def = function def(node) {
     return '(' + node.locals.join(' ') + ')';
 };
 

--- a/engine-test.js
+++ b/engine-test.js
@@ -36,16 +36,17 @@ function main() {
     test('tests/gradient.kni', 'tests/gradient.1');
     test('tests/indirect.kni', 'tests/indirect.1');
     test('tests/jump-and-ask.kni', 'tests/jump-and-ask.1');
+    test('tests/keyword-ambiguity.kni', 'tests/keyword-ambiguity.0');
     test('tests/keywords.kni', 'tests/keywords.1');
     test('tests/keywords.kni', 'tests/keywords.2');
     test('tests/keywords.kni', 'tests/keywords.3');
     test('tests/keywords.kni', 'tests/keywords.4');
     test('tests/keywords.kni', 'tests/keywords.5');
-    test('tests/keyword-ambiguity.kni', 'tests/keyword-ambiguity.0');
     test('tests/literals.kni', 'tests/literals.1');
     test('tests/loop.kni', 'tests/loop.1');
     test('tests/math.kni', 'tests/math.1');
     test('tests/no-option.kni', 'tests/no-option.1');
+    test('tests/number.kni', 'tests/number.1');
     test('tests/procedure.kni', 'tests/procedure.1');
     test('tests/program.kni', 'tests/program.1');
     test('tests/program.kni', 'tests/program.1');

--- a/engine-test.js
+++ b/engine-test.js
@@ -26,6 +26,8 @@ function main() {
     test('examples/option-styles.kni', 'tests/option-styles.1');
     test('examples/paint.kni', 'tests/paint.1');
     test('examples/plane.kni', 'tests/plane.1');
+    test('examples/subroutine.kni', 'tests/subroutine.1');
+    test('examples/subroutine.kni', 'tests/subroutine.2');
     test('examples/tree.kni', 'tests/tree.1');
 
     test('tests/brief.kni', 'tests/brief.1');

--- a/engine.js
+++ b/engine.js
@@ -18,7 +18,6 @@ function Engine(args) {
     this.noOption = null;
     this.global = new Global(this.handler);
     this.top = this.global;
-    this.stack = [this.top];
     this.label = '';
     // istanbul ignore next
     var start = args.start || 'start';
@@ -55,17 +54,27 @@ Engine.prototype.continue = function _continue() {
 };
 
 Engine.prototype.goto = function _goto(label) {
-    while (label == null && this.stack.length > 1) {
-        var top = this.stack.pop();
-        if (top.stopOption) {
+    while ((label == null || label == 'ESC' || label === 'END') && this.top != null) {
+        // istanbul ignore if
+        if (this.debug) {
+            console.log((label || 'END').toLowerCase());
+        }
+        if (this.top.stopOption) {
             this.render.stopOption();
         }
-        this.top = this.stack[this.stack.length - 1];
-        label = top.next;
+        if (label === 'ESC') {
+            label = this.top.branch;
+        } else {
+            label = this.top.next;
+        }
+        this.top = this.top.parent;
     }
-    if (label == null) {
+
+    // TODO remove special case for null
+    if (label == null || label === 'END') {
         return this.end();
     }
+
     var next = this.story[label];
     // istanbul ignore if
     if (!next) {
@@ -85,19 +94,14 @@ Engine.prototype.goto = function _goto(label) {
     return true;
 };
 
-Engine.prototype.gothrough = function gothrough(sequence, next, stopOption) {
+Engine.prototype.gothrough = function gothrough(sequence, next) {
     var prev = this.label;
-    for (var i = sequence.length -1; i >= 0; i--) {
-        // Note that we pass the top frame as both the parent scope and the
-        // caller scope so that the entire sequence has the same variable
-        // visibility.
+    for (var i = sequence.length - 1; i >= 0; i--) {
         if (next) {
-            this.top = new Frame(this.top, this.top, [], next, prev, stopOption);
-            this.stack.push(this.top);
+            this.top = new Frame(this.top, [], next, null, prev);
         }
         prev = next;
         next = sequence[i];
-        stopOption = false;
     }
     return this.goto(next);
 };
@@ -119,9 +123,12 @@ Engine.prototype.ask = function ask() {
         }
         this.dialog.ask();
     } else if (this.noOption != null) {
-        var answer = this.noOption.answer;
+        var closure = this.noOption;
+        var option = this.story[closure.label];
+        this.top = closure.scope;
+        var answer = option.answer;
         this.flush();
-        this.gothrough(answer, null, false);
+        this.gothrough(answer, null);
         this.continue();
     } else {
         return this.goto(this.instruction.next);
@@ -144,19 +151,22 @@ Engine.prototype.answer = function answer(text) {
     }
 };
 
-Engine.prototype.choice = function _choice(choice) {
+Engine.prototype.choice = function _choice(closure) {
+    var option = this.story[closure.label];
     if (this.handler && this.handler.choice) {
-        this.handler.choice(choice, this);
+        this.handler.choice(option, this);
     }
     this.render.clear();
-    this.waypoint = this.capture(choice.answer);
+    this.waypoint = this.capture(option.answer);
     if (this.handler && this.handler.waypoint) {
         this.handler.waypoint(this.waypoint, this);
     }
+    // Resume in the option's closure scope.
+    this.top = closure.scope;
     // There is no known case where gothrough would immediately exit for
     // lack of further instructions, so
     // istanbul ignore else
-    if (this.gothrough(choice.answer, null, false)) {
+    if (this.gothrough(option.answer, null)) {
         this.flush();
         this.continue();
     }
@@ -206,7 +216,6 @@ Engine.prototype.resume = function resume(state) {
     this.label = '';
     this.global = new Global(this.handler);
     this.top = this.global;
-    this.stack = [this.top];
     if (state == null) {
         if (this.handler && this.handler.waypoint) {
             this.handler.waypoint(null, this);
@@ -220,7 +229,6 @@ Engine.prototype.resume = function resume(state) {
     var stack = state[2];
     for (var i = 0; i < stack.length; i++) {
         this.top = Frame.resume(this.top, this.global, stack[i]);
-        this.stack.push(this.top);
     }
     var global = state[3];
     var keys = global[0];
@@ -236,7 +244,7 @@ Engine.prototype.resume = function resume(state) {
     if (answer == null) {
         this.flush();
         this.continue();
-    } else if (this.gothrough(answer, null, false)) {
+    } else if (this.gothrough(answer, null)) {
         this.flush();
         this.continue();
     }
@@ -279,20 +287,21 @@ Engine.prototype.$goto = function $goto() {
 };
 
 Engine.prototype.$call = function $call() {
-    var procedure = this.story[this.instruction.branch];
+    var label = this.instruction.label;
+    var def = this.story[label];
     // istanbul ignore if
-    if (!procedure) {
-        console.error('no such procedure ' + this.instruction.branch, this.instruction);
+    if (!def) {
+        console.error('no such procedure ' + label, this.instruction);
         return this.resume();
     }
     // istanbul ignore if
-    if (procedure.type !== 'args') {
-        console.error('Can\'t call non-procedure ' + this.instruction.branch, this.instruction);
+    if (def.type !== 'def') {
+        console.error('Can\'t call non-procedure ' + label, this.instruction);
         return this.resume();
     }
     // istanbul ignore if
-    if (procedure.locals.length !== this.instruction.args.length) {
-        console.error('Argument length mismatch for ' + this.instruction.branch, this.instruction, procedure);
+    if (def.locals.length !== this.instruction.args.length) {
+        console.error('Argument length mismatch for ' + label, this.instruction, procedure);
         return this.resume();
     }
     // TODO replace this.global with closure scope if scoped procedures become
@@ -301,41 +310,39 @@ Engine.prototype.$call = function $call() {
     // capturing locals. As such the parser will need to retain a reference to
     // the enclosing procedure and note all of the child procedures as they are
     // encountered.
-    this.top = new Frame(this.top, this.global, procedure.locals, this.instruction.next, this.label);
-    if (this.instruction.next) {
-        this.stack.push(this.top);
-    }
+    this.top = new Frame(this.top, def.locals, this.instruction.next, this.instruction.branch, this.label);
     for (var i = 0; i < this.instruction.args.length; i++) {
         var arg = this.instruction.args[i];
         var value = evaluate(this.top.parent, this.randomer, arg);
-        this.top.set(procedure.locals[i], value);
+        this.top.set(def.locals[i], value);
     }
-    return this.goto(this.instruction.branch);
+    return this.goto(label);
 };
 
-Engine.prototype.$args = function $args() {
+Engine.prototype.$def = function $def() {
     // Procedure argument instructions exist as targets for labels as well as
     // for reference to locals in calls.
     return this.goto(this.instruction.next);
 };
 
 Engine.prototype.$opt = function $opt() {
-    var option = this.instruction;
-    for (var i = 0; i < option.keywords.length; i++) {
-        var keyword = option.keywords[i];
+    var closure = new Closure(this.top, this.label);
+    for (var i = 0; i < this.instruction.keywords.length; i++) {
+        var keyword = this.instruction.keywords[i];
         // The first option to introduce a keyword wins, not the last.
         if (!this.keywords[keyword]) {
-            this.keywords[keyword] = option;
+            this.keywords[keyword] = closure;
         }
     }
-    if (option.question.length) {
-        this.options.push(option);
+    if (this.instruction.question.length > 0) {
+        this.options.push(closure);
         this.render.startOption();
-        return this.gothrough(option.question, this.instruction.next, true);
+        this.top = new Frame(this.top, [], this.instruction.next, null, this.label, true);
+        return this.gothrough(this.instruction.question, null);
     } else if (this.noOption == null) {
-        this.noOption = option;
+        this.noOption = closure;
     }
-    return this.goto(option.next);
+    return this.goto(this.instruction.next);
 };
 
 Engine.prototype.$move = function $move() {
@@ -402,7 +409,7 @@ Engine.prototype.$switch = function $switch() {
     if (this.debug) {
         console.log(this.top.at() + '/' + this.label + ' ' + value + ' -> ' + next);
     }
-    return this.gothrough(nexts, this.instruction.next, false);
+    return this.gothrough(nexts, this.instruction.next);
 };
 
 function weigh(scope, randomer, expressions, weights) {
@@ -491,18 +498,16 @@ Global.prototype.capture = function capture() {
     ];
 };
 
-// TODO names of parent and caller are not right, might be swapped.
-// parent should be the scope parent for upchain lookups.
-function Frame(parent, caller, locals, next, branch, stopOption) {
+function Frame(parent, locals, next, branch, label, stopOption) {
     this.locals = locals;
     this.scope = Object.create(null);
     for (var i = 0; i < locals.length; i++) {
         this.scope[locals[i]] = 0;
     }
     this.parent = parent;
-    this.caller = caller;
     this.next = next;
     this.branch = branch;
+    this.label = label;
     this.stopOption = stopOption || false;
 }
 
@@ -510,7 +515,7 @@ Frame.prototype.get = function get(name) {
     if (this.locals.indexOf(name) >= 0) {
         return this.scope[name];
     }
-    return this.caller.get(name);
+    return this.parent.get(name);
 };
 
 Frame.prototype.set = function set(name, value) {
@@ -519,13 +524,13 @@ Frame.prototype.set = function set(name, value) {
         this.scope[name] = value;
         return;
     }
-    this.caller.set(name, value);
+    this.parent.set(name, value);
 };
 
 // istanbul ignore next
 Frame.prototype.log = function log() {
     this.parent.log();
-    console.log('--- ' + this.branch + ' -> ' + this.next);
+    console.log('--- ' + this.label + ' -> ' + this.next);
     for (var i = 0; i < this.locals.length; i++) {
         var name = this.locals[i];
         var value = this.scope[name];
@@ -535,7 +540,7 @@ Frame.prototype.log = function log() {
 
 // istanbul ignore next
 Frame.prototype.at = function at() {
-    return this.caller.at() + '/' + this.branch;
+    return this.parent.at() + '/' + this.label;
 };
 
 // istanbul ignore next
@@ -551,7 +556,7 @@ Frame.prototype.capture = function capture() {
         values,
         this.next || "",
         this.branch || "",
-        +(this.caller === this.top),
+        this.label || "",
         +this.stopOption
     ];
 };
@@ -562,18 +567,17 @@ Frame.resume = function resume(top, global, state) {
     var values = state[1];
     var next = state[2];
     var branch = state[3];
-    var dynamic = state[4];
-    var stopOption = state[5];
-    top = new Frame(
-        top,
-        dynamic ? top : global,
-        keys,
-        next,
-        branch,
-        !!stopOption
-    );
+    var label = state[4];
+    var stopOption = state[6];
+    top = new Frame(top, keys, next, branch, label, !!stopOption);
     for (var i = 0; i < keys.length; i++) {
         top.set(keys[i], values[i]);
     }
     return top;
 };
+
+function Closure(scope, label) {
+    this.scope = scope;
+    this.label = label;
+    Object.seal(this);
+}

--- a/engine.js
+++ b/engine.js
@@ -55,7 +55,7 @@ Engine.prototype.continue = function _continue() {
 };
 
 Engine.prototype.goto = function _goto(label) {
-    while (this.top != null && (label == 'ESC' || label === 'END')) {
+    while (this.top != null && (label == 'ESC' || label === 'RET')) {
         // istanbul ignore if
         if (this.debug) {
             console.log(label.toLowerCase());
@@ -71,7 +71,7 @@ Engine.prototype.goto = function _goto(label) {
         this.top = this.top.parent;
     }
 
-    if (label === 'END') {
+    if (label === 'RET') {
         return this.end();
     }
 
@@ -97,8 +97,8 @@ Engine.prototype.goto = function _goto(label) {
 Engine.prototype.gothrough = function gothrough(sequence, next) {
     var prev = this.label;
     for (var i = sequence.length - 1; i >= 0; i--) {
-        if (next !== 'END') {
-            this.top = new Frame(this.top, [], next, 'END', prev);
+        if (next !== 'RET') {
+            this.top = new Frame(this.top, [], next, 'RET', prev);
         }
         prev = next;
         next = sequence[i];
@@ -128,10 +128,10 @@ Engine.prototype.ask = function ask() {
         this.top = closure.scope;
         var answer = option.answer;
         this.flush();
-        this.gothrough(answer, 'END');
+        this.gothrough(answer, 'RET');
         this.continue();
     } else {
-        return this.goto('END');
+        return this.goto('RET');
     }
 };
 
@@ -166,7 +166,7 @@ Engine.prototype.choice = function _choice(closure) {
     // There is no known case where gothrough would immediately exit for
     // lack of further instructions, so
     // istanbul ignore else
-    if (this.gothrough(option.answer, 'END')) {
+    if (this.gothrough(option.answer, 'RET')) {
         this.flush();
         this.continue();
     }
@@ -259,7 +259,7 @@ Engine.prototype.resume = function resume(snapshot) {
 
     var instruction = this.story[label];
     if (instruction.type === 'opt') {
-        if (this.gothrough(instruction.answer, 'END')) {
+        if (this.gothrough(instruction.answer, 'RET')) {
             this.flush();
             this.continue();
         }
@@ -357,8 +357,8 @@ Engine.prototype.$opt = function $opt() {
     if (this.instruction.question.length > 0) {
         this.options.push(closure);
         this.render.startOption();
-        this.top = new Frame(this.top, [], this.instruction.next, 'END', this.label, true);
-        return this.gothrough(this.instruction.question, 'END');
+        this.top = new Frame(this.top, [], this.instruction.next, 'RET', this.label, true);
+        return this.gothrough(this.instruction.question, 'RET');
     } else if (this.noOption == null) {
         this.noOption = closure;
     }
@@ -466,8 +466,8 @@ Engine.prototype.$ask = function $ask() {
 function Global(handler) {
     this.scope = Object.create(null);
     this.handler = handler;
-    this.next = 'END';
-    this.branch = 'END';
+    this.next = 'RET';
+    this.branch = 'RET';
     Object.seal(this);
 }
 
@@ -604,7 +604,7 @@ Frame.restore = function (engine, snapshot, parent) {
 
 Engine.prototype.labelOfIndex = function (index) {
     if (index == -2) {
-        return 'END';
+        return 'RET';
     } else if (index === -3) {
         return 'ESC';
     }
@@ -612,7 +612,7 @@ Engine.prototype.labelOfIndex = function (index) {
 };
 
 Engine.prototype.indexOfLabel = function (label) {
-    if (label === 'END') {
+    if (label === 'RET') {
         return -2;
     } else if (label === 'ESC') {
         return -3;

--- a/examples/subroutine.kni
+++ b/examples/subroutine.kni
@@ -1,0 +1,23 @@
+# A subroutine can add options to a menu.
+- @kind(t, u)
+  + [Choose {(t)}x{(u)}. ] Chose {(t)}x{(u)}.
+
+# A subroutine can aggregate menu sections, and add text to
+# the overall description while adding options.
+- @type(t)
+  You may choose from kind {(t)}.
+  ->kind(t, 1)
+  ->kind(t, 2)
+
+->type(1)
+->type(2)
++ [Skip. ] Skipped. <-
+>
+
+# Even though choices are captured in the subroutines, the
+# selection jumps over the prompt, so this text gets
+# printed for all choices except skip.
+Your choice is noted.
++ [Ask another. ] Asking another. ->start
++ [Done. ]
+>

--- a/grammar.js
+++ b/grammar.js
@@ -9,7 +9,7 @@ exports.start = start;
 function start(story) {
     var path = Path.start();
     var stop = new Stop(story);
-    var start = story.create(path, 'goto', 'END', '1:1');
+    var start = story.create(path, 'goto', 'RET', '1:1');
     return new Thread(story, Path.zerothChild(path), stop, [start], []);
 }
 
@@ -27,9 +27,9 @@ Stop.prototype.next = function next(type, space, text, scanner) {
     return new End();
 };
 
-Stop.prototype.return = function _return(path, ends, jumps, scanner) {
-    tie(ends, ['END']);
-    tie(jumps, ['ESC']);
+Stop.prototype.return = function _return(path, rets, escs, scanner) {
+    tie(rets, 'RET');
+    tie(escs, 'ESC');
     return this;
 };
 
@@ -42,89 +42,89 @@ End.prototype.next = function next(type, space, text, scanner) {
     return this;
 };
 
-// ends are tied to the next instruction
-// jumps are tied off after the next encountered prompt
-function Thread(story, path, parent, ends, jumps) {
+// rets are tied to the next instruction
+// escs are tied off after the next encountered prompt
+function Thread(story, path, parent, rets, escs) {
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
-    this.jumps = jumps;
+    this.rets = rets;
+    this.escs = escs;
     this.story = story;
     Object.freeze(this);
 }
 
 Thread.prototype.next = function next(type, space, text, scanner) {
     if (type === 'symbol'|| type === 'alphanum' || type === 'number' || type === 'literal' || text === '--' || text === '---') {
-        return new Text(this.story, this.path, space, text, this, this.ends);
+        return new Text(this.story, this.path, space, text, this, this.rets);
     }  else if (type === 'token') {
         if (text === '{') {
-            return new Block(this.story, this.path, new ThenExpect('token', '}', this.story, this), this.ends);
+            return new Block(this.story, this.path, new ThenExpect('token', '}', this.story, this), this.rets);
         } else if (text === '@') {
-            return expression.label(this.story, new Label(this.story, this.path, this, this.ends));
+            return expression.label(this.story, new Label(this.story, this.path, this, this.rets));
         } else if (text === '->') {
-            return expression.label(this.story, new Goto(this.story, this.path, this, this.ends));
+            return expression.label(this.story, new Goto(this.story, this.path, this, this.rets));
         } else if (text === '<-') {
-            // Explicitly tie ends to null by dropping them.
-            tie(this.ends, ['END']);
-            // Continue carrying jumps to the next encountered prompt.
+            // Explicitly tie rets to null by dropping them.
+            tie(this.rets, 'RET');
+            // Continue carrying escs to the next encountered prompt.
             // Advance the path so that option thread don't appear empty.
-            return new Thread(this.story, Path.next(this.path), this.parent, [], this.jumps);
+            return new Thread(this.story, Path.next(this.path), this.parent, [], this.escs);
         } else if (text === '/') {
             var node = this.story.create(this.path, 'break', scanner.position());
-            tie(this.ends, this.path);
-            return new Thread(this.story, Path.next(this.path), this.parent, [node], this.jumps);
+            tiePath(this.rets, this.path);
+            return new Thread(this.story, Path.next(this.path), this.parent, [node], this.escs);
         } else if (text === '//') {
             var node = this.story.create(this.path, 'paragraph', null, scanner.position());
-            tie(this.ends, this.path);
-            return new Thread(this.story, Path.next(this.path), this.parent, [node], this.jumps);
+            tiePath(this.rets, this.path);
+            return new Thread(this.story, Path.next(this.path), this.parent, [node], this.escs);
         } else if (text === '{"' || text === '{\'' || text === '"}' || text === '\'}') {
-            return new Text(this.story, this.path, space, '', this, this.ends)
+            return new Text(this.story, this.path, space, '', this, this.rets)
                 .next(type, '', text, scanner);
         }
     } else if (type === 'start') {
         if (text === '+' || text === '*') {
-            return new MaybeOption(this.story, this.path, new ThenExpect('stop', '', this.story, this), this.ends, [], text);
+            return new MaybeOption(this.story, this.path, new ThenExpect('stop', '', this.story, this), this.rets, [], text);
         } else if (text === '-') {
-            return new MaybeThread(this.story, this.path, new ThenExpect('stop', '', this.story, this), this.ends, [], [], ' ');
+            return new MaybeThread(this.story, this.path, new ThenExpect('stop', '', this.story, this), this.rets, [], [], ' ');
         } else if (text === '>') {
             var node = this.story.create(this.path, 'ask', null, scanner.position());
-            // tie off ends to the prompt.
-            tie(this.ends, this.path);
-            // promote jumps to ends, tying them off after the prompt.
-            var jumps = this.jumps.slice();
-            this.jumps.length = 0;
-            return new Thread(this.story, Path.next(this.path), new ThenExpect('stop', '', this.story, this), jumps, []);
+            // tie off rets to the prompt.
+            tiePath(this.rets, this.path);
+            // promote escs to rets, tying them off after the prompt.
+            var escs = this.escs.slice();
+            this.escs.length = 0;
+            return new Thread(this.story, Path.next(this.path), new ThenExpect('stop', '', this.story, this), escs, []);
         } else { // if text === '!') {
-            return new Program(this.story, this.path, new ThenExpect('stop', '', this.story, this), this.ends, []);
+            return new Program(this.story, this.path, new ThenExpect('stop', '', this.story, this), this.rets, []);
         }
     } else if (type === 'dash') {
         var node = this.story.create(this.path, 'rule', scanner.position());
-        tie(this.ends, this.path);
-        return new Thread(this.story, Path.next(this.path), this.parent, [node], this.jumps);
+        tiePath(this.rets, this.path);
+        return new Thread(this.story, Path.next(this.path), this.parent, [node], this.escs);
     } else if (type === 'break') {
         return this;
     }
     if (type === 'stop' || text === '|' || text === ']' || text === '[' || text === '}') {
-        return this.parent.return(this.path, this.ends, this.jumps, scanner)
+        return this.parent.return(this.path, this.rets, this.escs, scanner)
             .next(type, space, text, scanner);
     }
-    return new Text(this.story, this.path, space, text, this, this.ends);
+    return new Text(this.story, this.path, space, text, this, this.rets);
 };
 
-Thread.prototype.return = function _return(path, ends, jumps, scanner) {
-    // All rules above (in next) guarantee that this.ends has been passed to
+Thread.prototype.return = function _return(path, rets, escs, scanner) {
+    // All rules above (in next) guarantee that this.rets has been passed to
     // any rule that might use them. If the rule fails to use them, they must
-    // return them. However, jumps are never passed to any rule that returns.
-    return new Thread(this.story, path, this.parent, ends, this.jumps.concat(jumps));
+    // return them. However, escs are never passed to any rule that returns.
+    return new Thread(this.story, path, this.parent, rets, this.escs.concat(escs));
 };
 
-function Text(story, path, lift, text, parent, ends) {
+function Text(story, path, lift, text, parent, rets) {
     this.story = story;
     this.path = path;
     this.lift = lift;
     this.text = text;
     this.parent = parent;
-    this.ends = ends;
+    this.rets = rets;
     Object.seal(this);
 }
 
@@ -153,7 +153,7 @@ Text.prototype.next = function next(type, space, text, scanner) {
         this.text += space + '—'; // em-dash
         return this;
     }
-    tie(this.ends, this.path);
+    tiePath(this.rets, this.path);
     var node = this.story.create(this.path, 'text', this.text, scanner.position());
     node.lift = this.lift;
     node.drop = space;
@@ -161,12 +161,12 @@ Text.prototype.next = function next(type, space, text, scanner) {
         .next(type, space, text, scanner);
 };
 
-function MaybeThread(story, path, parent, ends, jumps, skips, space) {
+function MaybeThread(story, path, parent, rets, escs, skips, space) {
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
-    this.jumps = jumps;
+    this.rets = rets;
+    this.escs = escs;
     this.skips = skips;
     this.space = space || '';
 };
@@ -176,23 +176,23 @@ MaybeThread.prototype.next = function next(type, space, text, scanner) {
         if (text === '{') {
             return expression(this.story,
                 new ThenExpect('token', '}', this.story,
-                    new ThreadCondition(this.story, this.path, this.parent, this.ends, this.jumps, this.skips)));
+                    new ThreadCondition(this.story, this.path, this.parent, this.rets, this.escs, this.skips)));
         }
     }
-    return new Thread(this.story, this.path, this, this.ends, this.jumps)
+    return new Thread(this.story, this.path, this, this.rets, this.escs)
         .next(type, this.space || space, text, scanner);
 };
 
-MaybeThread.prototype.return = function _return(path, ends, jumps, scanner) {
-    return this.parent.return(path, ends.concat(this.skips), jumps, scanner);
+MaybeThread.prototype.return = function _return(path, rets, escs, scanner) {
+    return this.parent.return(path, rets.concat(this.skips), escs, scanner);
 };
 
-function ThreadCondition(story, path, parent, ends, jumps, skips) {
+function ThreadCondition(story, path, parent, rets, escs, skips) {
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
-    this.jumps = jumps;
+    this.rets = rets;
+    this.escs = escs;
     this.skips = skips;
     Object.freeze(this);
 }
@@ -200,16 +200,16 @@ function ThreadCondition(story, path, parent, ends, jumps, skips) {
 ThreadCondition.prototype.return = function _return(args, scanner) {
     var node = this.story.create(this.path, 'jump', expression.invert(args), scanner.position());
     var branch = new Branch(node);
-    tie(this.ends, this.path);
-    return new MaybeThread(this.story, Path.next(this.path), this.parent, [node], this.jumps, this.skips.concat([branch]));
+    tiePath(this.rets, this.path);
+    return new MaybeThread(this.story, Path.next(this.path), this.parent, [node], this.escs, this.skips.concat([branch]));
 };
 
-function MaybeOption(story, path, parent, ends, jumps, leader) {
+function MaybeOption(story, path, parent, rets, escs, leader) {
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
-    this.jumps = jumps;
+    this.rets = rets;
+    this.escs = escs;
     this.leader = leader;
     this.conditions = [];
     this.consequences = [];
@@ -263,29 +263,29 @@ MaybeOption.prototype.advance = function advance() {
 
 MaybeOption.prototype.option = function option(scanner) {
     var variable = Path.toName(this.path);
-    var ends = [];
+    var rets = [];
 
-    tie(this.ends, this.at);
+    tiePath(this.rets, this.at);
 
     if (this.leader === '*') {
         this.consequences.push([['get', variable], ['+', ['get', variable], ['val', 1]]]);
         var jump = this.story.create(this.at, 'jump', ['<>', ['get', variable], ['val', 0]], scanner.position());
         var jumpBranch = new Branch(jump);
-        ends.push(jumpBranch);
+        rets.push(jumpBranch);
         this.advance();
-        tie([jump], this.at);
+        tiePath([jump], this.at);
     }
 
     for (var i = 0; i < this.conditions.length; i++) {
         var condition = this.conditions[i];
         var jump = this.story.create(this.at, 'jump', ['==', condition, ['val', 0]], scanner.position());
         var jumpBranch = new Branch(jump);
-        ends.push(jumpBranch);
+        rets.push(jumpBranch);
         this.advance();
-        tie([jump], this.at);
+        tiePath([jump], this.at);
     }
 
-    var option = new Option(this.story, this.path, this.parent, ends, this.jumps, this.leader, this.consequences);
+    var option = new Option(this.story, this.path, this.parent, rets, this.escs, this.leader, this.consequences);
     option.node = this.story.create(this.at, 'option', null, scanner.position());
     option.node.keywords = Object.keys(this.keywords).sort();
     this.advance();
@@ -358,12 +358,12 @@ OptionArgument2.prototype.return = function _return(args, scanner) {
     return this.parent.return(this.operator, args, this.args, scanner);
 };
 
-function Option(story, path, parent, ends, jumps, leader, consequences) {
+function Option(story, path, parent, rets, escs, leader, consequences) {
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends; // to tie off to the next option
-    this.jumps = jumps; // to tie off to the next node after the next prompt
+    this.rets = rets; // to tie off to the next option
+    this.escs = escs; // to tie off to the next node after the next prompt
     this.node = null;
     this.leader = leader;
     this.consequences = consequences;
@@ -373,29 +373,29 @@ function Option(story, path, parent, ends, jumps, leader, consequences) {
     Object.seal(this);
 }
 
-Option.prototype.return = function _return(path, ends, jumps, scanner) {
+Option.prototype.return = function _return(path, rets, escs, scanner) {
     // Create a jump from the end of the answer.
     if (this.mode !== 'a') {
         // If the answer is reused in the question, create a dedicated jump and
         // add it to the end of the answer.
-        var jump = this.story.create(path, 'goto', 'END', scanner.position());
+        var jump = this.story.create(path, 'goto', 'RET', scanner.position());
         this.node.answer.push(Path.toName(path));
         path = Path.next(path);
-        ends.push(jump);
+        rets.push(jump);
     }
 
     return this.parent.return(
         Path.next(this.path),
-        this.ends.concat([this.node]),
-        this.jumps.concat(ends, jumps),
+        this.rets.concat([this.node]),
+        this.escs.concat(rets, escs),
         scanner
     );
 };
 
 Option.prototype.thread = function thread(scanner, parent) {
     // Creat a dummy node, to replace if necessary, for arcs that begin with a
-    // goto/divert arrow that otherwise would have loose ends to forward.
-    var placeholder = this.story.create(this.next, 'goto', 'END', scanner.position());
+    // goto/divert arrow that otherwise would have loose rets to forward.
+    var placeholder = this.story.create(this.next, 'goto', 'RET', scanner.position());
     return new Thread(this.story, this.next, parent, [placeholder], []);
 };
 
@@ -417,35 +417,35 @@ Option.prototype.push = function push(path, mode) {
 // An option thread captures the end of an arc, and if the path has advanced,
 // adds that arc to the option's questions and/or answer depending on the
 // "mode" ("q", "a", or "qa") and proceeds to the following state.
-function OptionThread(story, path, parent, ends, option, mode, Next) {
+function OptionThread(story, path, parent, rets, option, mode, Next) {
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
+    this.rets = rets;
     this.option = option;
     this.mode = mode;
     this.Next = Next;
     Object.freeze(this);
 }
 
-OptionThread.prototype.return = function _return(path, ends, jumps, scanner) {
+OptionThread.prototype.return = function _return(path, rets, escs, scanner) {
     this.option.push(path, this.mode);
-    // TODO investigate whether we can consistently tie of received ends
+    // TODO investigate whether we can consistently tie of received rets
     // instead of passing them forward to OptionThread, which consistently
     // just terminates them on their behalf.
-    tie(this.ends, ['END']);
+    tie(this.rets, 'RET');
     // TODO no test exercises this kind of jump.
-    tie(jumps, ['ESC']);
-    return new this.Next(this.story, path, this.parent, ends, this.option);
+    tie(escs, 'ESC');
+    return new this.Next(this.story, path, this.parent, rets, this.option);
 };
 
 // Every option begins with a (potentially empty) thread before the first open
 // backet that will contribute both to the question and the answer.
-function AfterInitialQA(story, path, parent, ends, option) {
+function AfterInitialQA(story, path, parent, rets, option) {
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
+    this.rets = rets;
     this.option = option;
     Object.freeze(this);
 }
@@ -453,22 +453,22 @@ function AfterInitialQA(story, path, parent, ends, option) {
 AfterInitialQA.prototype.next = function next(type, space, text, scanner) {
     // istanbul ignore else
     if (type === 'token' && text === '[') {
-        return this.option.thread(scanner, new AfterQorA(this.story, this.path, this, this.ends, this.option));
+        return this.option.thread(scanner, new AfterQorA(this.story, this.path, this, this.rets, this.option));
     } else {
         this.story.error('Expected brackets in option at ' + scanner.position());
-        return this.return(this.path, this.ends, this.jumps, scanner);
+        return this.return(this.path, this.rets, this.escs, scanner);
     }
 };
 
 // The thread returns to this level after capturing the bracketed terms, after
 // which anything and everything to the end of the block contributes to the
 // answer.
-AfterInitialQA.prototype.return = function _return(path, ends, jumps, scanner) {
-    tie(ends, ['END']);
-    // TODO no test exercises these jumps.
-    tie(jumps, ['ESC']);
+AfterInitialQA.prototype.return = function _return(path, rets, escs, scanner) {
+    tie(rets, 'RET');
+    // TODO no test exercises these escs.
+    tie(escs, 'ESC');
 
-    ends = [];
+    rets = [];
 
     // Thread consequences, including incrementing the option variable name
     var consequences = this.option.consequences;
@@ -480,24 +480,24 @@ AfterInitialQA.prototype.return = function _return(path, ends, jumps, scanner) {
         var node = this.story.create(path, 'move', null, scanner.position());
         node.source = consequence[1];
         node.target = consequence[0];
-        tie(ends, path);
+        tiePath(rets, path);
         path = Path.next(path);
-        ends = [node];
+        rets = [node];
     }
 
     this.option.next = path;
     return this.option.thread(scanner,
-        new OptionThread(this.story, path, this.parent, ends, this.option, 'a', AfterFinalA));
+        new OptionThread(this.story, path, this.parent, rets, this.option, 'a', AfterFinalA));
 };
 
 // After capturing the first arc within brackets, which may either contribute
 // to the question or the answer, we decide which based on whether there is a
 // following bracket.
-function DecideQorA(story, path, parent, ends, option) {
+function DecideQorA(story, path, parent, rets, option) {
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
+    this.rets = rets;
     this.option = option;
     Object.freeze(this);
 }
@@ -506,34 +506,34 @@ DecideQorA.prototype.next = function next(type, space, text, scanner) {
     if (type === 'token' && text === '[') { // A
         this.option.push(this.path, 'a');
         return this.option.thread(scanner,
-            new OptionThread(this.story, this.path, this, this.ends, this.option, 'q', ExpectFinalBracket));
+            new OptionThread(this.story, this.path, this, this.rets, this.option, 'q', ExpectFinalBracket));
     // istanbul ignore else
     } else if (type === 'token' && text === ']') { // Q
         this.option.push(this.path, 'q');
-        return this.parent.return(this.path, this.ends, [], scanner);
+        return this.parent.return(this.path, this.rets, [], scanner);
     } else {
         this.story.error('Expected a bracket, either [ or ], at ' + scanner.position());
-        return this.parent.return(this.path, this.ends, [], scanner);
+        return this.parent.return(this.path, this.rets, [], scanner);
     }
 };
 
 // If the brackets contain a sequence of question thread like [A [Q] QA [Q]
 // QA...], then after each [question], we return here for continuing QA arcs.
-DecideQorA.prototype.return = function _return(path, ends, jumps, scanner) {
-    // TODO no test exercises these jumps.
-    tie(jumps, ['ESC']);
+DecideQorA.prototype.return = function _return(path, rets, escs, scanner) {
+    // TODO no test exercises these escs.
+    tie(escs, 'ESC');
     return this.option.thread(scanner,
-        new OptionThread(this.story, path, this.parent, ends, this.option, 'qa', AfterQA));
+        new OptionThread(this.story, path, this.parent, rets, this.option, 'qa', AfterQA));
 };
 
 // After a Question/Answer thread, there can always be another [Q] thread
 // ad nauseam. Here we check whether this is the end of the bracketed
 // expression or continue after a [Question].
-function AfterQA(story, path, parent, ends, option) {
+function AfterQA(story, path, parent, rets, option) {
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
+    this.rets = rets;
     this.option = option;
     Object.freeze(this);
 }
@@ -541,51 +541,51 @@ function AfterQA(story, path, parent, ends, option) {
 AfterQA.prototype.next = function next(type, space, text, scanner) {
     if (type === 'token' && text === '[') {
         return this.option.thread(scanner,
-            new OptionThread(this.story, this.path, this, this.ends, this.option, 'q', ExpectFinalBracket));
+            new OptionThread(this.story, this.path, this, this.rets, this.option, 'q', ExpectFinalBracket));
     // istanbul ignore else
     } else  if (type === 'token' && text === ']') {
-        return this.parent.return(this.path, this.ends, [], scanner);
+        return this.parent.return(this.path, this.rets, [], scanner);
     } else {
         this.story.error('Expected either [ or ] bracket at ' + scanner.position());
-        return this.parent.return(this.path, this.ends, [], scanner);
+        return this.parent.return(this.path, this.rets, [], scanner);
     }
 };
 
-AfterQA.prototype.return = function _return(path, ends, jumps, scanner) {
+AfterQA.prototype.return = function _return(path, rets, escs, scanner) {
     // TODO no test exercises these escapes.
-    tie(jumps, ['ESC']);
+    tie(escs, 'ESC');
     return this.option.thread(scanner,
-        new OptionThread(this.story, this.path, this.parent, ends, this.option, 'qa', ExpectFinalBracket));
+        new OptionThread(this.story, this.path, this.parent, rets, this.option, 'qa', ExpectFinalBracket));
 };
 
 // The bracketed terms may either take the form [Q] or [A, ([Q] QA)*].
 // This captures the first arc without committing to either Q or A until we
 // know whether it is followed by a bracketed term.
-function AfterQorA(story, path, parent, ends, option) {
+function AfterQorA(story, path, parent, rets, option) {
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
+    this.rets = rets;
     this.option = option;
     Object.freeze(this);
 }
 
 // Just capture the path and proceed.
-AfterQorA.prototype.return = function _return(path, ends, jumps, scanner) {
+AfterQorA.prototype.return = function _return(path, rets, escs, scanner) {
     // TODO consider whether this could have been done earlier.
-    tie(this.ends, ['END']);
+    tie(this.rets, 'RET');
     // TODO no test exercises these escapes.
-    tie(jumps, ['ESC']);
-    return new DecideQorA(this.story, path, this.parent, ends, this.option);
+    tie(escs, 'ESC');
+    return new DecideQorA(this.story, path, this.parent, rets, this.option);
 };
 
 // After a [Q] or [A [Q] QA...] block, there must be a closing bracket and we
 // return to the parent arc of the option.
-function ExpectFinalBracket(story, path, parent, ends, option) {
+function ExpectFinalBracket(story, path, parent, rets, option) {
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
+    this.rets = rets;
     this.option = option;
     Object.freeze(this);
 }
@@ -595,41 +595,40 @@ ExpectFinalBracket.prototype.next = function next(type, space, text, scanner) {
     if (type !== 'token' || text !== ']') {
         this.story.error('Expected close bracket in option at ' + scanner.position());
     }
-    return this.parent.return(this.path, this.ends, [], scanner);
+    return this.parent.return(this.path, this.rets, [], scanner);
 };
 
 // After the closing bracket in an option], everything that remains is the last
 // node of the answer. After that thread has been submitted, we expect the
 // block to end.
-function AfterFinalA(story, path, parent, ends, option) {
+function AfterFinalA(story, path, parent, rets, option) {
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
+    this.rets = rets;
     Object.freeze(this);
 }
 
 AfterFinalA.prototype.next = function next(type, space, text, scanner) {
-    return this.parent.return(this.path, this.ends, [], scanner)
+    return this.parent.return(this.path, this.rets, [], scanner)
         .next(type, space, text, scanner);
 };
 
 // This concludes the portion dedicated to parsing options
 
+// Branch is a fake story node. It serves to mark that the wrapped node's
+// "branch" label should be tied instead of its "next" label.
 function Branch(node) {
+    this.type = 'branch';
     this.node = node;
     Object.freeze(this);
 }
 
-Branch.prototype.tie = function tie(path) {
-    this.node.branch = path;
-};
-
-function Label(story, path, parent, ends) {
+function Label(story, path, parent, rets) {
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
+    this.rets = rets;
     Object.freeze(this);
 }
 
@@ -638,10 +637,10 @@ Label.prototype.return = function _return(expression, scanner) {
         var label = expression[1];
         var path = [label, 0];
         // place-holder goto thunk
-        var node = this.story.create(path, 'goto', 'END', scanner.position());
-        tie(this.ends, path);
-        // ends also forwarded so they can be tied off if the goto is replaced.
-        return this.parent.return(path, this.ends.concat([node]), [], scanner);
+        var node = this.story.create(path, 'goto', 'RET', scanner.position());
+        tiePath(this.rets, path);
+        // rets also forwarded so they can be tied off if the goto is replaced.
+        return this.parent.return(path, this.rets.concat([node]), [], scanner);
     // istanbul ignore else
     } else if (expression[0] === 'call') {
         var label = expression[1][1];
@@ -659,60 +658,60 @@ Label.prototype.return = function _return(expression, scanner) {
         }
         node.locals = params;
         return new Thread(this.story, Path.next(path),
-            new ConcludeProcedure(this.story, this.path, this.parent, this.ends),
+            new ConcludeProcedure(this.story, this.path, this.parent, this.rets),
             [node], []);
     } else {
         this.story.error('Expected label after @, got ' + JSON.stringify(expression) + ' at ' + scanner.position());
-        return new Thread(this.story, this.path, this.parent, this.ends, []);
+        return new Thread(this.story, this.path, this.parent, this.rets, []);
     }
 };
 
-function ConcludeProcedure(story, path, parent, ends) {
+function ConcludeProcedure(story, path, parent, rets) {
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
+    this.rets = rets;
     Object.freeze(this);
 };
 
-ConcludeProcedure.prototype.return = function _return(path, ends, jumps, scanner) {
-    // After a procedure, connect prior ends.
-    tie(ends, ['END']);
-    // Dangling jumps go to an escape instruction, to follow the jump path in
+ConcludeProcedure.prototype.return = function _return(path, rets, escs, scanner) {
+    // After a procedure, connect prior rets.
+    tie(rets, 'RET');
+    // Dangling escs go to an escape instruction, to follow the jump path in
     // the parent scope, determined at run time.
-    tie(jumps, ['ESC']);
-    return this.parent.return(this.path, this.ends, [], scanner);
+    tie(escs, 'ESC');
+    return this.parent.return(this.path, this.rets, [], scanner);
 };
 
-function Goto(story, path, parent, ends, jumps) {
+function Goto(story, path, parent, rets, escs) {
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
+    this.rets = rets;
 }
 
 Goto.prototype.return = function _return(args, scanner) {
     // istanbul ignore else
     if (args[0] === 'get') {
-        tieName(this.ends, args[1]);
+        tie(this.rets, args[1]);
         return this.parent.return(Path.next(this.path), [], [], scanner);
     } else if (args[0] === 'call') {
         var label = args[1][1];
         var node = this.story.create(this.path, 'call', label, scanner.position());
         node.args = args.slice(2);
-        tie(this.ends, this.path);
+        tiePath(this.rets, this.path);
         return this.parent.return(Path.next(this.path), [node], [new Branch(node)], scanner);
     } else {
         this.story.error('Expected label after goto arrow, got expression ' + JSON.stringify(args) + ' at ' + scanner.position());
-        return new Thread(this.story, this.path, this.parent, this.ends, []);
+        return new Thread(this.story, this.path, this.parent, this.rets, []);
     }
 };
 
-function Block(story, path, parent, ends) {
+function Block(story, path, parent, rets) {
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
+    this.rets = rets;
 }
 
 var mutators = {
@@ -737,41 +736,41 @@ var switches = {
 Block.prototype.next = function next(type, space, text, scanner) {
     if (type === 'symbol' || type === 'alphanum' || type === 'token') {
         if (text === '(') {
-            return expression(this.story, new ExpressionBlock(this.story, this.path, this.parent, this.ends, 'walk'))
+            return expression(this.story, new ExpressionBlock(this.story, this.path, this.parent, this.rets, 'walk'))
                 .next(type, space, text, scanner);
         } else if (mutators[text]) {
-            return expression(this.story, new SetBlock(this.story, this.path, this.parent, this.ends, text));
+            return expression(this.story, new SetBlock(this.story, this.path, this.parent, this.rets, text));
         } else if (variables[text]) {
-            return expression(this.story, new ExpressionBlock(this.story, this.path, this.parent, this.ends, variables[text]));
+            return expression(this.story, new ExpressionBlock(this.story, this.path, this.parent, this.rets, variables[text]));
         } else if (text === '!') {
-            return new Program(this.story, this.path, this.parent, this.ends, []);
+            return new Program(this.story, this.path, this.parent, this.rets, []);
         } else if (switches[text]) {
-            return new SwitchBlock(this.story, this.path, this.parent, this.ends)
+            return new SwitchBlock(this.story, this.path, this.parent, this.rets)
                 .start(scanner, null, Path.toName(this.path), null, switches[text]);
         }
     }
-    return new SwitchBlock(this.story, this.path, this.parent, this.ends)
+    return new SwitchBlock(this.story, this.path, this.parent, this.rets)
         .start(scanner, null, Path.toName(this.path), 1, 'walk') // with variable and value, waiting for case to start
         .next(type, space, text, scanner);
 };
 
-function SetBlock(story, path, parent, ends, op) {
+function SetBlock(story, path, parent, rets, op) {
     this.op = op;
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
+    this.rets = rets;
 }
 
 SetBlock.prototype.return = function _return(expression, scanner) {
-    return new MaybeSetVariable(this.story, this.path, this.parent, this.ends, this.op, expression);
+    return new MaybeSetVariable(this.story, this.path, this.parent, this.rets, this.op, expression);
 };
 
-function MaybeSetVariable(story, path, parent, ends, op, expression) {
+function MaybeSetVariable(story, path, parent, rets, op, expression) {
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
+    this.rets = rets;
     this.op = op;
     this.expression = expression;
 }
@@ -793,7 +792,7 @@ MaybeSetVariable.prototype.set = function set(source, target, scanner) {
         node.source = [this.op, target, source];
     }
     node.target = target;
-    tie(this.ends, this.path);
+    tiePath(this.rets, this.path);
     return this.parent.return(Path.next(this.path), [node], [], scanner);
 };
 
@@ -801,23 +800,23 @@ MaybeSetVariable.prototype.return = function _return(target, scanner) {
     return this.set(this.expression, target, scanner);
 };
 
-function ExpressionBlock(story, path, parent, ends, mode) {
+function ExpressionBlock(story, path, parent, rets, mode) {
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
+    this.rets = rets;
     this.mode = mode;
 }
 
 ExpressionBlock.prototype.return = function _return(expression, scanner) {
-    return new AfterExpressionBlock(this.story, this.path, this.parent, this.ends, this.mode, expression);
+    return new AfterExpressionBlock(this.story, this.path, this.parent, this.rets, this.mode, expression);
 };
 
-function AfterExpressionBlock(story, path, parent, ends, mode, expression) {
+function AfterExpressionBlock(story, path, parent, rets, mode, expression) {
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
+    this.rets = rets;
     this.mode = mode;
     this.expression = expression;
     Object.freeze(this);
@@ -825,15 +824,15 @@ function AfterExpressionBlock(story, path, parent, ends, mode, expression) {
 
 AfterExpressionBlock.prototype.next = function next(type, space, text, scanner) {
     if (text === '|') {
-        return new SwitchBlock(this.story, this.path, this.parent, this.ends)
+        return new SwitchBlock(this.story, this.path, this.parent, this.rets)
             .start(scanner, this.expression, null, 0, this.mode);
     } else if (text === '?') {
-        return new SwitchBlock(this.story, this.path, this.parent, this.ends)
+        return new SwitchBlock(this.story, this.path, this.parent, this.rets)
             .start(scanner, expression.invert(this.expression), null, 0, this.mode, 2);
     // istanbul ignore else
     } else if (text === '}') {
         var node = this.story.create(this.path, 'echo', this.expression, scanner.position());
-        tie(this.ends, this.path);
+        tiePath(this.rets, this.path);
         return this.parent.return(Path.next(this.path), [node], [], scanner)
             .next(type, space, text, scanner);
     } else {
@@ -843,11 +842,11 @@ AfterExpressionBlock.prototype.next = function next(type, space, text, scanner) 
     }
 };
 
-function SwitchBlock(story, path, parent, ends) {
+function SwitchBlock(story, path, parent, rets) {
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
+    this.rets = rets;
     this.node = null;
     this.branches = [];
     this.weights = [];
@@ -864,28 +863,28 @@ SwitchBlock.prototype.start = function start(scanner, expression, variable, valu
     node.variable = variable;
     node.value = value;
     node.mode = mode;
-    tie(this.ends, this.path);
+    tiePath(this.rets, this.path);
     node.branches = this.branches;
     node.weights = this.weights;
     return new MaybeWeightedCase(this.story, new Case(this.story, Path.firstChild(this.path), this, [], this.branches, min || 0));
 };
 
-SwitchBlock.prototype.return = function _return(path, ends, jumps, scanner) {
+SwitchBlock.prototype.return = function _return(path, rets, escs, scanner) {
     if (this.node.mode === 'pick') {
-        tie(ends, ['END']);
-        ends = [this.node];
-        // TODO think about what to do with jumps.
+        tie(rets, 'RET');
+        rets = [this.node];
+        // TODO think about what to do with escs.
     } else {
-        this.node.next = 'END';
+        this.node.next = 'RET';
     }
-    return this.parent.return(Path.next(this.path), ends, jumps, scanner);
+    return this.parent.return(Path.next(this.path), rets, escs, scanner);
 };
 
-function Case(story, path, parent, ends, branches, min) {
+function Case(story, path, parent, rets, branches, min) {
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
+    this.rets = rets;
     this.branches = branches;
     this.min = min;
     Object.freeze(this);
@@ -897,12 +896,12 @@ Case.prototype.next = function next(type, space, text, scanner) {
     } else {
         var path = this.path;
         while (this.branches.length < this.min) {
-            var node = this.story.create(path, 'goto', 'END', scanner.position());
-            this.ends.push(node);
+            var node = this.story.create(path, 'goto', 'RET', scanner.position());
+            this.rets.push(node);
             this.branches.push(Path.toName(path));
             path = Path.next(path);
         }
-        return this.parent.return(path, this.ends, [], scanner)
+        return this.parent.return(path, this.rets, [], scanner)
             .next(type, space, text, scanner);
     }
 };
@@ -910,13 +909,13 @@ Case.prototype.next = function next(type, space, text, scanner) {
 Case.prototype.case = function _case(args, scanner) {
     this.parent.weights.push(args || ['val', 1]);
     var path = Path.zerothChild(this.path);
-    var node = this.story.create(path, 'goto', 'END', scanner.position());
+    var node = this.story.create(path, 'goto', 'RET', scanner.position());
     this.branches.push(Path.toName(path));
     return new Thread(this.story, path, this, [node], []);
 };
 
-Case.prototype.return = function _return(path, ends, jumps, scanner) {
-    return new Case(this.story, Path.next(this.path), this.parent, this.ends.concat(ends, jumps), this.branches, this.min);
+Case.prototype.return = function _return(path, rets, escs, scanner) {
+    return new Case(this.story, Path.next(this.path), this.parent, this.rets.concat(rets, escs), this.branches, this.min);
 };
 
 function MaybeWeightedCase(story, parent) {
@@ -938,61 +937,61 @@ MaybeWeightedCase.prototype.return = function _return(args, scanner) {
     return this.parent.case(args, scanner);
 };
 
-function Program(story, path, parent, ends, jumps) {
+function Program(story, path, parent, rets, escs) {
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
-    this.jumps = jumps;
+    this.rets = rets;
+    this.escs = escs;
     Object.freeze(this);
 }
 
 Program.prototype.next = function next(type, space, text, scanner) {
     if (type === 'stop' || text === '}') {
-        return this.parent.return(this.path, this.ends, this.jumps, scanner)
+        return this.parent.return(this.path, this.rets, this.escs, scanner)
             .next(type, space, text, scanner);
     } else if (text === ',' || type === 'break') {
         return this;
     // istanbul ignore if
     } else if (type === 'error') {
         // Break out of recursive error loops
-        return this.parent.return(this.path, this.ends, this.jumps, scanner);
+        return this.parent.return(this.path, this.rets, this.escs, scanner);
     } else {
-        return expression.variable(this.story, new Assignment(this.story, this.path, this, this.ends, this.jumps))
+        return expression.variable(this.story, new Assignment(this.story, this.path, this, this.rets, this.escs))
             .next(type, space, text, scanner);
     }
 };
 
-Program.prototype.return = function _return(path, ends, jumps, scanner) {
-    return new Program(this.story, path, this.parent, ends, jumps);
+Program.prototype.return = function _return(path, rets, escs, scanner) {
+    return new Program(this.story, path, this.parent, rets, escs);
 };
 
-function Assignment(story, path, parent, ends, jumps) {
+function Assignment(story, path, parent, rets, escs) {
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
-    this.jumps = jumps;
+    this.rets = rets;
+    this.escs = escs;
     Object.freeze(this);
 }
 
 Assignment.prototype.return = function _return(expression, scanner) {
     // istanbul ignore else
     if (expression[0] === 'get' || expression[0] === 'var') {
-        return new ExpectOperator(this.story, this.path, this.parent, this.ends, this.jumps, expression);
+        return new ExpectOperator(this.story, this.path, this.parent, this.rets, this.escs, expression);
     } else {
         this.story.error('Expected variable to assign, got: ' + JSON.stringify(expression) + ' at ' + scanner.position());
-        return this.parent.return(this.path, this.ends, this.jumps, scanner)
+        return this.parent.return(this.path, this.rets, this.escs, scanner)
             .next('error', '', '', scanner);
     }
 };
 
-function ExpectOperator(story, path, parent, ends, jumps, left) {
+function ExpectOperator(story, path, parent, rets, escs, left) {
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
-    this.jumps = jumps;
+    this.rets = rets;
+    this.escs = escs;
     this.left = left;
     Object.freeze(this);
 }
@@ -1000,19 +999,19 @@ function ExpectOperator(story, path, parent, ends, jumps, left) {
 ExpectOperator.prototype.next = function next(type, space, text, scanner) {
     // istanbul ignore else
     if (text === '=') {
-        return expression(this.story, new ExpectExpression(this.story, this.path, this.parent, this.ends, this.jumps, this.left, text));
+        return expression(this.story, new ExpectExpression(this.story, this.path, this.parent, this.rets, this.escs, this.left, text));
     } else {
         this.story.error('Expected = operator, got ' + type + '/' + text + ' at ' + scanner.position());
-        return this.parent.return(this.path, this.ends, this.jumps, scanner);
+        return this.parent.return(this.path, this.rets, this.escs, scanner);
     }
 };
 
-function ExpectExpression(story, path, parent, ends, jumps, left, operator) {
+function ExpectExpression(story, path, parent, rets, escs, left, operator) {
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
-    this.jumps = jumps;
+    this.rets = rets;
+    this.escs = escs;
     this.left = left;
     this.operator = operator;
 }
@@ -1020,11 +1019,11 @@ function ExpectExpression(story, path, parent, ends, jumps, left, operator) {
 ExpectExpression.prototype.return = function _return(right, scanner) {
     var node;
     // TODO validate this.left as a valid move target
-    tie(this.ends, this.path);
+    tiePath(this.rets, this.path);
     node = this.story.create(this.path, 'move', null, scanner.position());
     node.target = this.left;
     node.source = right;
-    return this.parent.return(Path.next(this.path), [node], this.jumps, scanner);
+    return this.parent.return(Path.next(this.path), [node], this.escs, scanner);
 };
 
 function ThenExpect(expect, text, story, parent) {
@@ -1035,18 +1034,18 @@ function ThenExpect(expect, text, story, parent) {
     Object.freeze(this);
 }
 
-ThenExpect.prototype.return = function _return(path, ends, jumps, scanner) {
-    return new Expect(this.expect, this.text, this.story, path, this.parent, ends, jumps);
+ThenExpect.prototype.return = function _return(path, rets, escs, scanner) {
+    return new Expect(this.expect, this.text, this.story, path, this.parent, rets, escs);
 };
 
-function Expect(expect, text, story, path, parent, ends, jumps) {
+function Expect(expect, text, story, path, parent, rets, escs) {
     this.expect = expect;
     this.text = text;
     this.story = story;
     this.path = path;
     this.parent = parent;
-    this.ends = ends;
-    this.jumps = jumps;
+    this.rets = rets;
+    this.escs = escs;
     Object.freeze(this);
 }
 
@@ -1055,17 +1054,21 @@ Expect.prototype.next = function next(type, space, text, scanner) {
     if (type !== this.expect || text !== this.text) {
         this.story.error('Expected ' + this.expect + '/' + this.text + ', got ' + type + '/' + text + ' at ' + scanner.position());
     }
-    return this.parent.return(this.path, this.ends, this.jumps, scanner);
+    return this.parent.return(this.path, this.rets, this.escs, scanner);
 };
 
-function tie(ends, next) {
+function tiePath(ends, next) {
     var name = Path.toName(next);
-    tieName(ends, name);
+    tie(ends, name);
 }
 
-function tieName(ends, name) {
+function tie(ends, name) {
     for (var i = 0; i < ends.length; i++) {
         var end = ends[i];
-        end.tie(name);
+        if (end.type === 'branch') {
+            end.node.branch = name;
+        } else {
+            end.next = name;
+        }
     }
 }

--- a/kni.js
+++ b/kni.js
@@ -223,8 +223,10 @@ function describeNext(jump, next) {
         return '';
     } else if (jump === next) {
         return '';
-    } else if (jump == null) {
+    } else if (jump == 'END') {
         return '<-';
+    } else if (jump == 'ESC') {
+        return '<<';
     } else {
         return '-> ' + jump;
     }

--- a/kni.js
+++ b/kni.js
@@ -223,7 +223,7 @@ function describeNext(jump, next) {
         return '';
     } else if (jump === next) {
         return '';
-    } else if (jump == 'END') {
+    } else if (jump == 'RET') {
         return '<-';
     } else if (jump == 'ESC') {
         return '<<';

--- a/scanner.js
+++ b/scanner.js
@@ -96,7 +96,7 @@ Scanner.prototype.return = function _return() {
 
 // istanbul ignore next
 Scanner.prototype.position = function position() {
-    return (this.lineStart + 1) + ':' + (this.columnStart + 1);
+    return (this.lineNo + 1) + ':' + (this.columnStart + 1);
 };
 
 function nextTabStop(columnNo) {

--- a/story.js
+++ b/story.js
@@ -38,11 +38,10 @@ function Text(text) {
     this.text = text;
     this.lift = ' ';
     this.drop = ' ';
-    this.next = 'END';
+    this.next = 'RET';
     this.position = null;
     Object.seal(this);
 }
-Text.prototype.tie = tie;
 
 constructors.echo = Echo;
 function Echo(expression) {
@@ -50,11 +49,10 @@ function Echo(expression) {
     this.expression = expression;
     this.lift = '';
     this.drop = '';
-    this.next = 'END';
+    this.next = 'RET';
     this.position = null;
     Object.seal(this);
 }
-Echo.prototype.tie = tie;
 
 constructors.option = Option;
 function Option(label) {
@@ -62,11 +60,10 @@ function Option(label) {
     this.question = [];
     this.answer = [];
     this.keywords = null;
-    this.next = 'END';
+    this.next = 'RET';
     this.position = null;
     Object.seal(this);
 }
-Option.prototype.tie = tie;
 
 constructors.goto = Goto;
 function Goto(next) {
@@ -75,40 +72,36 @@ function Goto(next) {
     this.position = null;
     Object.seal(this);
 }
-Goto.prototype.tie = tie;
 
 constructors.call = Call;
 function Call(label) {
     this.type = 'call';
     this.label = label;
     this.args = null;
-    this.next = 'END';
-    this.branch = 'END';
+    this.next = 'RET';
+    this.branch = 'RET';
     this.position = null;
     Object.seal(this);
 }
-Call.prototype.tie = tie;
 
 constructors.def = Def;
 function Def(locals) {
     this.type = 'def';
     this.locals = locals;
-    this.next = 'END';
+    this.next = 'RET';
     this.position = null;
     Object.seal(this);
 }
-Def.prototype.tie = tie;
 
 constructors.jump = Jump;
 function Jump(condition) {
     this.type = 'jump';
     this.condition = condition;
-    this.branch = 'END';
-    this.next = 'END';
+    this.branch = 'RET';
+    this.next = 'RET';
     this.position = null;
     Object.seal(this);
 }
-Jump.prototype.tie = tie;
 
 constructors.switch = Switch;
 function Switch(expression) {
@@ -119,58 +112,48 @@ function Switch(expression) {
     this.mode = null;
     this.branches = [];
     this.weights = [];
-    this.next = 'END';
+    this.next = 'RET';
     this.position = null;
     Object.seal(this);
 }
-Switch.prototype.tie = tie;
 
 constructors.move = Move;
 function Move() {
     this.type = 'move';
     this.source = null;
     this.target = null;
-    this.next = 'END';
+    this.next = 'RET';
     this.position = null;
     Object.seal(this);
 }
-Move.prototype.tie = tie;
 
 constructors.break = Break;
 function Break() {
     this.type = 'br';
-    this.next = 'END';
+    this.next = 'RET';
     this.position = null;
     Object.seal(this);
 }
-Break.prototype.tie = tie;
 
 constructors.paragraph = Paragraph;
 function Paragraph() {
     this.type = 'par';
-    this.next = 'END';
+    this.next = 'RET';
     this.position = null;
     Object.seal(this);
 }
-Paragraph.prototype.tie = tie;
 
 constructors.rule = Rule;
 function Rule() {
     this.type = 'rule';
-    this.next = 'END';
+    this.next = 'RET';
     this.position = null;
     Object.seal(this);
 }
-Rule.prototype.tie = tie;
 
 constructors.ask = Ask;
 function Ask(variable) {
     this.type = 'ask';
     this.position = null;
     Object.seal(this);
-}
-Ask.prototype.tie = tie;
-
-function tie(end) {
-    this.next = end;
 }

--- a/story.js
+++ b/story.js
@@ -38,7 +38,7 @@ function Text(text) {
     this.text = text;
     this.lift = ' ';
     this.drop = ' ';
-    this.next = null;
+    this.next = 'END';
     this.position = null;
     Object.seal(this);
 }
@@ -50,7 +50,7 @@ function Echo(expression) {
     this.expression = expression;
     this.lift = '';
     this.drop = '';
-    this.next = null;
+    this.next = 'END';
     this.position = null;
     Object.seal(this);
 }
@@ -62,7 +62,7 @@ function Option(label) {
     this.question = [];
     this.answer = [];
     this.keywords = null;
-    this.next = null;
+    this.next = 'END';
     this.position = null;
     Object.seal(this);
 }
@@ -82,8 +82,8 @@ function Call(label) {
     this.type = 'call';
     this.label = label;
     this.args = null;
-    this.next = null;
-    this.branch = null;
+    this.next = 'END';
+    this.branch = 'END';
     this.position = null;
     Object.seal(this);
 }
@@ -93,7 +93,7 @@ constructors.def = Def;
 function Def(locals) {
     this.type = 'def';
     this.locals = locals;
-    this.next = null;
+    this.next = 'END';
     this.position = null;
     Object.seal(this);
 }
@@ -103,8 +103,8 @@ constructors.jump = Jump;
 function Jump(condition) {
     this.type = 'jump';
     this.condition = condition;
-    this.branch = null;
-    this.next = null;
+    this.branch = 'END';
+    this.next = 'END';
     this.position = null;
     Object.seal(this);
 }
@@ -119,7 +119,7 @@ function Switch(expression) {
     this.mode = null;
     this.branches = [];
     this.weights = [];
-    this.next = null;
+    this.next = 'END';
     this.position = null;
     Object.seal(this);
 }
@@ -130,7 +130,7 @@ function Move() {
     this.type = 'move';
     this.source = null;
     this.target = null;
-    this.next = null;
+    this.next = 'END';
     this.position = null;
     Object.seal(this);
 }
@@ -139,7 +139,7 @@ Move.prototype.tie = tie;
 constructors.break = Break;
 function Break() {
     this.type = 'br';
-    this.next = null;
+    this.next = 'END';
     this.position = null;
     Object.seal(this);
 }
@@ -148,7 +148,7 @@ Break.prototype.tie = tie;
 constructors.paragraph = Paragraph;
 function Paragraph() {
     this.type = 'par';
-    this.next = null;
+    this.next = 'END';
     this.position = null;
     Object.seal(this);
 }
@@ -157,7 +157,7 @@ Paragraph.prototype.tie = tie;
 constructors.rule = Rule;
 function Rule() {
     this.type = 'rule';
-    this.next = null;
+    this.next = 'END';
     this.position = null;
     Object.seal(this);
 }

--- a/story.js
+++ b/story.js
@@ -78,25 +78,26 @@ function Goto(next) {
 Goto.prototype.tie = tie;
 
 constructors.call = Call;
-function Call(branch) {
+function Call(label) {
     this.type = 'call';
-    this.branch = branch;
+    this.label = label;
     this.args = null;
     this.next = null;
+    this.branch = null;
     this.position = null;
     Object.seal(this);
 }
 Call.prototype.tie = tie;
 
-constructors.args = Args;
-function Args(locals) {
-    this.type = 'args';
+constructors.def = Def;
+function Def(locals) {
+    this.type = 'def';
     this.locals = locals;
     this.next = null;
     this.position = null;
     Object.seal(this);
 }
-Args.prototype.tie = tie;
+Def.prototype.tie = tie;
 
 constructors.jump = Jump;
 function Jump(condition) {

--- a/story.js
+++ b/story.js
@@ -71,7 +71,7 @@ Option.prototype.tie = tie;
 constructors.goto = Goto;
 function Goto(next) {
     this.type = 'goto';
-    this.next = next || null;
+    this.next = next;
     this.position = null;
     Object.seal(this);
 }

--- a/test.js
+++ b/test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+Error.stackTraceLimit = 1024;
+
 require('./outline-lexer-test');
 require('./inline-lexer-test');
 require('./engine-test');

--- a/tests/nominal.1
+++ b/tests/nominal.1
@@ -1,3 +1,3 @@
-minus two billion, eight hundred fifty-two million, five
-hundred sixteen thousand, three hundred fifty-two.
+minus two billion, one hundred forty-seven million, four
+hundred eighty-three thousand, six hundred forty-eight.
 

--- a/tests/number.1
+++ b/tests/number.1
@@ -1,0 +1,70 @@
+0
+1.  Increment.
+2.  Decrement.
+3.  Fork.
+4.  Join.
+> replay
+
+0
+1.  Increment.
+2.  Decrement.
+3.  Fork.
+4.  Join.
+> 1
+
+Increment. 1
+1.  Increment.
+2.  Decrement.
+3.  Fork.
+4.  Join.
+> back
+
+0
+1.  Increment.
+2.  Decrement.
+3.  Fork.
+4.  Join.
+> 1
+
+Increment. 1
+1.  Increment.
+2.  Decrement.
+3.  Fork.
+4.  Join.
+> 3
+
+Fork. 1
+1.  Increment.
+2.  Decrement.
+3.  Fork.
+4.  Join.
+> 1
+
+Increment. 2
+1.  Increment.
+2.  Decrement.
+3.  Fork.
+4.  Join.
+> back
+
+Fork. 1
+1.  Increment.
+2.  Decrement.
+3.  Fork.
+4.  Join.
+> back
+
+Increment. 1
+1.  Increment.
+2.  Decrement.
+3.  Fork.
+4.  Join.
+> back
+
+0
+1.  Increment.
+2.  Decrement.
+3.  Fork.
+4.  Join.
+> quit
+

--- a/tests/number.kni
+++ b/tests/number.kni
@@ -1,0 +1,11 @@
+
+- @loop(x)
+  {(x)}
+  + [[]Increment. ] {+x}
+  + [[]Decrement. ] {-x}
+  + [[]Fork. ] ->loop(x)
+  + [[]Join. ] <-
+  >
+  ->loop
+
+->loop(0)

--- a/tests/subroutine.1
+++ b/tests/subroutine.1
@@ -1,0 +1,38 @@
+You may choose from kind 1. You may choose from kind 2.
+1.  Choose 1x1.
+2.  Choose 1x2.
+3.  Choose 2x1.
+4.  Choose 2x2.
+5.  Skip.
+> 3
+
+Chose 2x1. Your choice is noted.
+1.  Ask another.
+2.  Done.
+> 1
+
+Asking another. You may choose from kind 1. You may choose
+from kind 2.
+1.  Choose 1x1.
+2.  Choose 1x2.
+3.  Choose 2x1.
+4.  Choose 2x2.
+5.  Skip.
+> 1
+
+Chose 1x1. Your choice is noted.
+1.  Ask another.
+2.  Done.
+> 1
+
+Asking another. You may choose from kind 1. You may choose
+from kind 2.
+1.  Choose 1x1.
+2.  Choose 1x2.
+3.  Choose 2x1.
+4.  Choose 2x2.
+5.  Skip.
+> 5
+
+Skipped.
+

--- a/tests/subroutine.2
+++ b/tests/subroutine.2
@@ -1,0 +1,14 @@
+You may choose from kind 1. You may choose from kind 2.
+1.  Choose 1x1.
+2.  Choose 1x2.
+3.  Choose 2x1.
+4.  Choose 2x2.
+5.  Skip.
+> 4
+
+Chose 2x2. Your choice is noted.
+1.  Ask another.
+2.  Done.
+> 2
+
+

--- a/verify.js
+++ b/verify.js
@@ -85,6 +85,8 @@ function FakeReadline(writer, answers) {
     this.writer = writer;
     this.answers = answers;
     this.engine = null;
+    this.history = [];
+    Object.seal(this);
 }
 
 FakeReadline.prototype.ask = function ask(question) {
@@ -94,7 +96,19 @@ FakeReadline.prototype.ask = function ask(question) {
         return;
     }
     this.writer.write(((question || '> ') + answer).trim() + '\n');
-    this.engine.answer(answer);
+
+    if (answer === 'quit') {
+    } else if (answer === 'replay') {
+        this.writer.write('\n');
+        this.engine.resume(this.engine.waypoint);
+    } else if (answer === 'back') {
+        this.writer.write('\n');
+        this.engine.waypoint = this.history.pop();
+        this.engine.resume(this.engine.waypoint);
+    } else {
+        this.history.push(this.engine.waypoint);
+        this.engine.answer(answer);
+    }
 };
 
 FakeReadline.prototype.close = function close() {


### PR DESCRIPTION
Subroutines can now generate options for the next prompt.
This works by capturing a "closure" for each option, both the option object and
the scope in which it was added, so that chosing that option causes the game to
resume from that scope.
Stack frames now also capture an alternate address to jump to when returning
from a subroutine following an option.
Thus, a subroutine exits once after declaring an option, and we exit again,
jumping past the next prompt, if we choose an option. 

This change makes it much easier to write subroutines that capture common
options. Those subroutines are now decoupled from the jump destination.

This necessitated some changes to how state was captured and restored.
I've almost completely desymbolicated the JSON representation of interactive
story state (global names remain), using numbers for the offsets of labels
instead of the labels proper.
This also adds integration testing for replay and backing through history.

A major incidental change is that END and ESC are now special jump locations,
instead of overloading null.