### PR TITLE
Minor fixes to manual

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -184,7 +184,7 @@ An expression in braces serves as a condition, without which the option
 is not available.
 
 An expression with the plus `+` prefix denotes a product of the choice.
-Chosing this option increases the variable.
+Choosing this option increases the variable.
 
 An expression with the minus `-` prefix is a component that gets
 consumed with the option. So, `{-2coal}` would indicate that the option
@@ -428,7 +428,7 @@ in the callee scope.
 
 ## Returning or exiting
 
-In the above example, the greet procedure impicitly returns at the end of the thread.
+In the above example, the greet procedure implicitly returns at the end of the thread.
 The reverse arrow will skip to the end of a procedure.
 For the main narrative, this means exiting out the bottom of the file.
 Within a procedure, this means exiting out the end of the procedure.
@@ -539,10 +539,10 @@ Kni also supports "hypergeometric sampling", or rather "sampling without
 replacement".
 With the "^" prefix followed by an expression, you can determine the number
 of threads to sample from the alternation.
-Once a thread has been sampled, it is inelligible for the next sample, until
+Once a thread has been sampled, it is ineligible for the next sample, until
 the number of samples or the number of threads has been exhausted.
 Samples can also have weights.
-If the weight of a thread is 0, it is inelligible for sampling.
+If the weight of a thread is 0, it is ineligible for sampling.
 
 In the next example, there are threads, each catering to a different sense.
 Depending on the narrators perception of those senses, they may experience up

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -43,10 +43,10 @@ the generated narrative.
 
 ## Collapsed space
 
-For any two pieces of text, if there is any white space between the first text
-and the next symbol, or if there is any white space before the second
+For any two pieces of text, if there is any whitespace between the first text
+and the next symbol, or if there is any whitespace before the second
 text and the previous symbol, those pieces of text will be separated by
-white space in the generated narrative.
+whitespace in the generated narrative.
 
 The following lines are equivalent:
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -78,7 +78,7 @@ Was bedeudet, „Rindfleische{
 ## Indentation and threads
 
 Kni is a white-space significant language.
-All leading tabs and spaces, as well as bullet symbols, on a line contribute
+All leading tabs and spaces, as well as bullet symbols, on a line
 determine the initial column number of the line.
 Tabs advance the cursor to the next tab stop, which occur on every fourth
 column.

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -740,9 +740,9 @@ coordinates in a square of height and width 64k centered about the origin.
 
 Kni also supports a limited set of functions: `floor(x)`, `ceil(x)`,
 `round(x)`, `abs(x)`, `acos(t)`, `asin(t)`, `atan2(x, y)`, `exp(x, y)`,
-`log(x)` (natural log), `log(x, root)`, `max(n...)`, `min(n...)`, `pow(x, y)`,
+`log(x)` (natural log), `log(x, base)`, `max(n...)`, `min(n...)`, `pow(x, y)`,
 `sin(t)`, `tan(t)`, `sign(x)`, `mean(n...)`, `root(x)` (square root), `root(x,
-root)`, `distance(x1, y1, x2, y2)`, `manhattan(x1, y1, x2, y2)` (distance if
+n)`, `distance(x1, y1, x2, y2)`, `manhattan(x1, y1, x2, y2)` (distance if
 only travelling orthogonally to the x or y axes).
 
 ## Variables

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1,6 +1,6 @@
 # Kni Manual
 
-The following is an undigestable reference because I don’t yet have time to
+The following is an undigestable reference because I don't yet have time to
 write a graduated tutorial.
 
 Kni is a parser, compiler, and a runtime, all of which are accessible with
@@ -203,7 +203,7 @@ These primitives enable concise crafting formulae.
 
 Options, starting with plus or asterisk, have a special notation and use the
 additional symbols `[` and `]`.
-The form of this notation denotes text that is part of the narrator’s answer,
+The form of this notation denotes text that is part of the narrator's answer,
 question, and a part that is common to both.
 
 ```
@@ -310,7 +310,7 @@ Invisible options can also be chosen by keyword.
 2.  Choose orange or lemon.
 > grape
 
-You chose a grape, which wasn’t even on the menu.
+You chose a grape, which wasn't even on the menu.
 ```
 
 
@@ -727,7 +727,7 @@ mean value of 6, where 6 is the most likely variable, with diminishing
 probability toward 0 and 12. The D&D expression `2d6` is equivalent to
 `1~6 + 1~6 + 2` owing to the vagaries of math.
 
-I haven’t implemented simplified notation for die rolls, favoring the ~
+I haven't implemented simplified notation for die rolls, favoring the ~
 operator initially because it composes better mathematically.
 
 binary `#` produces the equivalent point on a Hilbert Curve for a coordinate X, Y.


### PR DESCRIPTION
- make apostrophes less "extra"
- we seem to call it "whitespace" most consistently
- a few spelos
- change 2nd arg name to math log and root functions to be more canonical; TBD if this should be mirrored in code I have yet to read ;-)