### PR TITLE
Regenerate package-lock.json, dropping unpm references

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,3 +1,15 @@
+# v4.0.3
+
+- Regenerated `package-lock.json`, dropping references to unpm from these packages:
+  - asap
+  - camelcase
+  - pop-iterate
+  - q
+  - rezult
+  - shon
+  - system
+  - weak-map
+- necessarily upgraded all dependencies, due to reinstalling sans version lock
 
 # v4.0.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,44 +1,521 @@
 {
   "name": "kni",
-  "version": "4.0.1",
-  "lockfileVersion": 1,
+  "version": "4.0.2",
+  "lockfileVersion": 2,
   "requires": true,
-  "dependencies": {
-    "asap": {
+  "packages": {
+    "": {
+      "version": "4.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "pop-equals": "^1.0.0",
+        "shon": "^4.0.0",
+        "system": "^1.0.6",
+        "table": "^3.7.8",
+        "tee": "^0.2.0",
+        "xorshift": "^1.1.1"
+      },
+      "bin": {
+        "kni": "kni.js"
+      },
+      "devDependencies": {
+        "eslint": "^2.7.0",
+        "istanbul": "^0.4.3",
+        "json-diff": "^0.3.1",
+        "opn": "^1.0.1"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+      "dev": true
+    },
+    "node_modules/acorn": {
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^3.0.4"
+      }
+    },
+    "node_modules/acorn-jsx/node_modules/acorn": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "dependencies": {
+        "co": "^4.6.0",
+        "json-stable-stringify": "^1.0.1"
+      }
+    },
+    "node_modules/ajv-keywords": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "peerDependencies": {
+        "ajv": ">=4.10.0"
+      }
+    },
+    "node_modules/amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.4.2"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/asap": {
       "version": "2.0.6",
-      "resolved": "https://unpm.uberinternal.com/asap/-/asap-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
-    "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://unpm.uberinternal.com/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+    "node_modules/async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
     },
-    "eslint": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.7.0.tgz",
-      "integrity": "sha1-sCrCR9E+xF6ltEo8OD3bb+2giwA=",
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "node_modules/caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "deprecated": "CircularJSON is in maintenance only, flatted is its successor.",
+      "dev": true
+    },
+    "node_modules/cli-color": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.1.7.tgz",
+      "integrity": "sha1-rcMgD6RxzCEbDaf1ZrcemLnWc0c=",
+      "dev": true,
+      "dependencies": {
+        "es5-ext": "0.8.x"
+      },
+      "engines": {
+        "node": ">=0.1.103"
+      }
+    },
+    "node_modules/cli-color/node_modules/es5-ext": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.8.2.tgz",
+      "integrity": "sha1-q6jZ4ZQ6iVrJaDemKjmz9V7NlKs=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+      "dev": true
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "node_modules/d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dev": true,
+      "dependencies": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "node_modules/difflib": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz",
+      "integrity": "sha1-teMDYabbAjF21WKJLbhZQKcY9H4=",
+      "dev": true,
+      "dependencies": {
+        "heap": ">= 0.2.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+      "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2",
+        "isarray": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dreamopt": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.6.0.tgz",
+      "integrity": "sha1-2BPM2sjTnYrVJndVFKE92mZNa0s=",
+      "dev": true,
+      "dependencies": {
+        "wordwrap": ">=0.0.2"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/es5-ext": {
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "dev": true,
+      "dependencies": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-map": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "dev": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
+      }
+    },
+    "node_modules/es6-set": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "dev": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "~0.3.5"
+      }
+    },
+    "node_modules/es6-set/node_modules/es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "dev": true,
+      "dependencies": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
+    "node_modules/es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "dev": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+      "dev": true,
+      "dependencies": {
+        "esprima": "^2.7.1",
+        "estraverse": "^1.9.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.2.0"
+      }
+    },
+    "node_modules/escodegen/node_modules/estraverse": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/escope": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "dev": true,
+      "dependencies": {
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
+      "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
+      "dev": true,
+      "dependencies": {
         "chalk": "^1.1.3",
         "concat-stream": "^1.4.6",
         "debug": "^2.1.1",
-        "doctrine": "^1.2.1",
+        "doctrine": "^1.2.2",
         "es6-map": "^0.1.3",
         "escope": "^3.6.0",
-        "espree": "3.1.3",
+        "espree": "^3.1.6",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
         "file-entry-cache": "^1.1.1",
         "glob": "^7.0.3",
         "globals": "^9.2.0",
-        "ignore": "^3.0.10",
+        "ignore": "^3.1.2",
         "imurmurhash": "^0.1.4",
         "inquirer": "^0.12.0",
         "is-my-json-valid": "^2.10.0",
         "is-resolvable": "^1.0.0",
         "js-yaml": "^3.5.1",
         "json-stable-stringify": "^1.0.0",
+        "levn": "^0.3.0",
         "lodash": "^4.0.0",
         "mkdirp": "^0.5.0",
         "optionator": "^0.8.1",
@@ -53,1418 +530,1903 @@
         "text-table": "~0.2.0",
         "user-home": "^2.0.0"
       },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/espree": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "dev": true,
       "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-              "dev": true
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "http://archive.local.uber.internal/npm/escape-string-regexp/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-              "dev": true
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "resolved": "http://archive.local.uber.internal/npm/has-ansi/has-ansi-2.0.0.tgz",
-              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "resolved": "http://archive.local.uber.internal/npm/ansi-regex/ansi-regex-2.0.0.tgz",
-                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
-                  "dev": true
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "resolved": "http://archive.local.uber.internal/npm/ansi-regex/ansi-regex-2.0.0.tgz",
-                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
-                  "dev": true
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "http://archive.local.uber.internal/npm/supports-color/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-              "dev": true
-            }
-          }
-        },
-        "concat-stream": {
-          "version": "1.5.1",
-          "resolved": "http://archive.local.uber.internal/npm/concat-stream/concat-stream-1.5.1.tgz",
-          "integrity": "sha1-87gKz54fSOOHXAaItBtsMWAu6hw=",
-          "dev": true,
-          "requires": {
-            "inherits": "~2.0.1",
-            "readable-stream": "~2.0.0",
-            "typedarray": "~0.0.5"
-          },
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.1",
-              "resolved": "http://archive.local.uber.internal/npm/inherits/inherits-2.0.1.tgz",
-              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-              "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~1.0.6",
-                "string_decoder": "~0.10.x",
-                "util-deprecate": "~1.0.1"
-              },
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "resolved": "http://archive.local.uber.internal/npm/core-util-is/core-util-is-1.0.2.tgz",
-                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-                  "dev": true
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                  "dev": true
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                  "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU=",
-                  "dev": true
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "resolved": "http://archive.local.uber.internal/npm/string_decoder/string_decoder-0.10.31.tgz",
-                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                  "dev": true
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "resolved": "http://archive.local.uber.internal/npm/util-deprecate/util-deprecate-1.0.2.tgz",
-                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-                  "dev": true
-                }
-              }
-            },
-            "typedarray": {
-              "version": "0.0.6",
-              "resolved": "http://archive.local.uber.internal/npm/typedarray/typedarray-0.0.6.tgz",
-              "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-              "dev": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "http://archive.local.uber.internal/npm/debug/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "0.7.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-              "dev": true
-            }
-          }
-        },
-        "doctrine": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.2.1.tgz",
-          "integrity": "sha1-rAxknXC5UB4W6XrLfsTicWj3RqM=",
-          "dev": true,
-          "requires": {
-            "esutils": "^1.1.6",
-            "isarray": "^1.0.0"
-          },
-          "dependencies": {
-            "esutils": {
-              "version": "1.1.6",
-              "resolved": "http://archive.local.uber.internal/npm/esutils/esutils-1.1.6.tgz",
-              "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
-              "dev": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-              "dev": true
-            }
-          }
-        },
-        "es6-map": {
-          "version": "0.1.3",
-          "resolved": "http://archive.local.uber.internal/npm/es6-map/es6-map-0.1.3.tgz",
-          "integrity": "sha1-/ljGZUxqzVTkOXzbcjedWbatWJQ=",
-          "dev": true,
-          "requires": {
-            "d": "~0.1.1",
-            "es5-ext": "~0.10.8",
-            "es6-iterator": "2",
-            "es6-set": "~0.1.3",
-            "es6-symbol": "~3.0.1",
-            "event-emitter": "~0.3.4"
-          },
-          "dependencies": {
-            "d": {
-              "version": "0.1.1",
-              "resolved": "http://archive.local.uber.internal/npm/d/d-0.1.1.tgz",
-              "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
-              "dev": true,
-              "requires": {
-                "es5-ext": "~0.10.2"
-              }
-            },
-            "es5-ext": {
-              "version": "0.10.11",
-              "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
-              "integrity": "sha1-gYTD5wWoIJSMLb4EOEk3mx29DEU=",
-              "dev": true,
-              "requires": {
-                "es6-iterator": "2",
-                "es6-symbol": "~3.0.2"
-              }
-            },
-            "es6-iterator": {
-              "version": "2.0.0",
-              "resolved": "http://archive.local.uber.internal/npm/es6-iterator/es6-iterator-2.0.0.tgz",
-              "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w=",
-              "dev": true,
-              "requires": {
-                "d": "^0.1.1",
-                "es5-ext": "^0.10.7",
-                "es6-symbol": "3"
-              }
-            },
-            "es6-set": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
-              "integrity": "sha1-lRa2dhwpZLkv9HlFYjOiR9xwfOg=",
-              "dev": true,
-              "requires": {
-                "d": "~0.1.1",
-                "es5-ext": "~0.10.11",
-                "es6-iterator": "2",
-                "es6-symbol": "3",
-                "event-emitter": "~0.3.4"
-              }
-            },
-            "es6-symbol": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
-              "integrity": "sha1-HpKIeMb15jVBYltLtN9K8H0VQhk=",
-              "dev": true,
-              "requires": {
-                "d": "~0.1.1",
-                "es5-ext": "~0.10.10"
-              }
-            },
-            "event-emitter": {
-              "version": "0.3.4",
-              "resolved": "http://archive.local.uber.internal/npm/event-emitter/event-emitter-0.3.4.tgz",
-              "integrity": "sha1-jWPd+0z+H647MsomXExyAiIIC7U=",
-              "dev": true,
-              "requires": {
-                "d": "~0.1.1",
-                "es5-ext": "~0.10.7"
-              }
-            }
-          }
-        },
-        "escope": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-          "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-          "dev": true,
-          "requires": {
-            "es6-map": "^0.1.3",
-            "es6-weak-map": "^2.0.1",
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          },
-          "dependencies": {
-            "es6-weak-map": {
-              "version": "2.0.1",
-              "resolved": "http://archive.local.uber.internal/npm/es6-weak-map/es6-weak-map-2.0.1.tgz",
-              "integrity": "sha1-DSu9iCfrX7S6j5f7/qUNQ9sh6oE=",
-              "dev": true,
-              "requires": {
-                "d": "^0.1.1",
-                "es5-ext": "^0.10.8",
-                "es6-iterator": "2",
-                "es6-symbol": "3"
-              },
-              "dependencies": {
-                "d": {
-                  "version": "0.1.1",
-                  "resolved": "http://archive.local.uber.internal/npm/d/d-0.1.1.tgz",
-                  "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
-                  "dev": true,
-                  "requires": {
-                    "es5-ext": "~0.10.2"
-                  }
-                },
-                "es5-ext": {
-                  "version": "0.10.11",
-                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
-                  "integrity": "sha1-gYTD5wWoIJSMLb4EOEk3mx29DEU=",
-                  "dev": true,
-                  "requires": {
-                    "es6-iterator": "2",
-                    "es6-symbol": "~3.0.2"
-                  }
-                },
-                "es6-iterator": {
-                  "version": "2.0.0",
-                  "resolved": "http://archive.local.uber.internal/npm/es6-iterator/es6-iterator-2.0.0.tgz",
-                  "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w=",
-                  "dev": true,
-                  "requires": {
-                    "d": "^0.1.1",
-                    "es5-ext": "^0.10.7",
-                    "es6-symbol": "3"
-                  }
-                },
-                "es6-symbol": {
-                  "version": "3.0.2",
-                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
-                  "integrity": "sha1-HpKIeMb15jVBYltLtN9K8H0VQhk=",
-                  "dev": true,
-                  "requires": {
-                    "d": "~0.1.1",
-                    "es5-ext": "~0.10.10"
-                  }
-                }
-              }
-            },
-            "esrecurse": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
-              "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
-              "dev": true,
-              "requires": {
-                "estraverse": "~4.1.0",
-                "object-assign": "^4.0.1"
-              },
-              "dependencies": {
-                "estraverse": {
-                  "version": "4.1.1",
-                  "resolved": "http://archive.local.uber.internal/npm/estraverse/estraverse-4.1.1.tgz",
-                  "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
-                  "dev": true
-                },
-                "object-assign": {
-                  "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
-                  "integrity": "sha1-mVBEVsNZi1ytT8WcJuipuxB/4L0=",
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "espree": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-3.1.3.tgz",
-          "integrity": "sha1-p3ymMJhsGbdNlVQbhFKYzW+qIow=",
-          "dev": true,
-          "requires": {
-            "acorn": "^3.0.4",
-            "acorn-jsx": "^2.0.1"
-          },
-          "dependencies": {
-            "acorn": {
-              "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.0.4.tgz",
-              "integrity": "sha1-BPJElQ/bj6+FUHrUgcLt7nrs3uw=",
-              "dev": true
-            },
-            "acorn-jsx": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-2.0.1.tgz",
-              "integrity": "sha1-Dt+YeKWGa8piX1KVWh7Z59jFEX4=",
-              "dev": true,
-              "requires": {
-                "acorn": "^2.0.1"
-              },
-              "dependencies": {
-                "acorn": {
-                  "version": "2.7.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
-                  "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "estraverse": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esrecurse/node_modules/estraverse": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+      "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "node_modules/exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ext": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "dev": true,
+      "dependencies": {
+        "type": "^2.0.0"
+      }
+    },
+    "node_modules/ext/node_modules/type": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.3.0.tgz",
+      "integrity": "sha512-rgPIqOdfK/4J9FhiVrZ3cveAjRRo5rsQBAIhnylX874y1DX/kEKSVdLsnuHB6l1KTjHyU01VjiMBHgU2adejyg==",
+      "dev": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "node_modules/figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
+      "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+      "dev": true,
+      "dependencies": {
+        "circular-json": "^0.3.1",
+        "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
+        "write": "^0.2.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "dependencies": {
+        "is-property": "^1.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "dev": true
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/heap": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
+      "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw=",
+      "dev": true
+    },
+    "node_modules/ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "dev": true
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/inquirer": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^1.1.0",
+        "ansi-regex": "^2.0.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "figures": "^1.3.5",
+        "lodash": "^4.3.0",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^3.1.2",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "dev": true
+    },
+    "node_modules/is-my-json-valid": {
+      "version": "2.20.5",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.5.tgz",
+      "integrity": "sha512-VTPuvvGQtxvCeghwspQu1rBgjYUT6FGxPlvFKbYuFtgc4ADsX3U5ihZOYN0qyU6u+d4X9xXb0IT5O6QpXKt87A==",
+      "dev": true,
+      "dependencies": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
+    "node_modules/is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "node_modules/istanbul": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+      "deprecated": "This module is no longer maintained, try this instead:\n  npm i nyc\nVisit https://istanbul.js.org/integrations for other alternatives.",
+      "dev": true,
+      "dependencies": {
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "istanbul": "lib/cli.js"
+      }
+    },
+    "node_modules/istanbul/node_modules/glob": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+      "dev": true,
+      "dependencies": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/istanbul/node_modules/supports-color": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+      "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/js-yaml/node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/json-diff": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-diff/-/json-diff-0.3.1.tgz",
+      "integrity": "sha1-bbw64tJeB1p/1xvNmHRFhmb7aBs=",
+      "dev": true,
+      "dependencies": {
+        "cli-color": "~0.1.6",
+        "difflib": "~0.2.1",
+        "dreamopt": "~0.6.0"
+      },
+      "bin": {
+        "json-diff": "bin/json-diff.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dependencies": {
+        "jsonify": "~0.0.0"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jsonpointer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
+      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/mini-map": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mini-map/-/mini-map-1.0.0.tgz",
+      "integrity": "sha1-lkHgEV2Zs9wTcRz4z9pMgZmJP04="
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "dev": true
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
+    "node_modules/next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
+    },
+    "node_modules/nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      }
+    },
+    "node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/opn": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz",
+      "integrity": "sha1-uQlkM0bQChq8l3qLlvPOPFPVz18=",
+      "dev": true,
+      "bin": {
+        "opn": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "node_modules/pluralize": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+      "dev": true
+    },
+    "node_modules/pop-equals": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pop-equals/-/pop-equals-1.0.0.tgz",
+      "integrity": "sha1-kEFPj9pxo3+IHR5eOi4C7ww7fgs=",
+      "dependencies": {
+        "mini-map": "^1.0.0"
+      }
+    },
+    "node_modules/pop-iterate": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pop-iterate/-/pop-iterate-1.0.1.tgz",
+      "integrity": "sha1-zqz9q0q/NT16DyqqLB/Hs/lBO6M="
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "node_modules/progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/q": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/q/-/q-2.0.3.tgz",
+      "integrity": "sha1-dbjbAlWhpa+C9Yw/Oqoe/sfQ0TQ=",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "pop-iterate": "^1.0.1",
+        "weak-map": "^1.0.5"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readline2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "dev": true,
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "mute-stream": "0.0.5"
+      }
+    },
+    "node_modules/require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "dependencies": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+      "dev": true
+    },
+    "node_modules/resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
+      "dependencies": {
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rezult": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/rezult/-/rezult-1.1.0.tgz",
+      "integrity": "sha1-Jymr+VQoe8+6feobp5qU+/8h+2s="
+    },
+    "node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/run-async": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0"
+      }
+    },
+    "node_modules/rx-lite": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "dev": true
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/shelljs": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
+      "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
+      "dev": true,
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shon": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/shon/-/shon-4.0.0.tgz",
+      "integrity": "sha512-LNUpqq+iQCH9w/G7JeXUZO2NGg3FtsvmQwpUjzgE4czrsiH8GjEvVflhn7qWHgODydHW492YrSdc4QRCtvDzVQ==",
+      "dependencies": {
+        "camelcase": "^1.2.1",
+        "rezult": "^1.1.0"
+      },
+      "bin": {
+        "shon": "bin/shon.js",
+        "usage2json": "bin/usage2json.js"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+      "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "amdefine": ">=0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true,
+      "bin": {
+        "strip-json-comments": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/system": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/system/-/system-1.3.0.tgz",
+      "integrity": "sha1-2ZR4vvsDzZ4v0vw0CyDNWrrRPfc=",
+      "dependencies": {
+        "q": "^2.0.3"
+      },
+      "bin": {
+        "bundle": "bundle.js",
+        "sysjs": "bundle.js"
+      }
+    },
+    "node_modules/table": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+      "dependencies": {
+        "ajv": "^4.7.0",
+        "ajv-keywords": "^1.0.0",
+        "chalk": "^1.1.1",
+        "lodash": "^4.0.0",
+        "slice-ansi": "0.0.4",
+        "string-width": "^2.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/table/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/table/node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tee": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/tee/-/tee-0.2.0.tgz",
+      "integrity": "sha1-2HtYIHoMmb1icXnCwsYjXj051yU=",
+      "dependencies": {
+        "through": "~1.1.1"
+      }
+    },
+    "node_modules/tee/node_modules/through": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/through/-/through-1.1.2.tgz",
+      "integrity": "sha1-NEpUJaN3MxTKfg62US+6+vdsC/4="
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "node_modules/type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+      "dev": true
+    },
+    "node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "node_modules/uglify-js": {
+      "version": "3.12.8",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.8.tgz",
+      "integrity": "sha512-fvBeuXOsvqjecUtF/l1dwsrrf5y2BCUk9AOJGzGcm6tE7vegku5u/YvqjyDaAGr422PLoLnrxg3EnRvTqsdC1w==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/user-home": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "dev": true,
+      "dependencies": {
+        "os-homedir": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "node_modules/weak-map": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.5.tgz",
+      "integrity": "sha1-eWkVhNmGB/UHC9O3CkDmuyLkAes="
+    },
+    "node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "node_modules/write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "dependencies": {
+        "mkdirp": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xorshift": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/xorshift/-/xorshift-1.1.1.tgz",
+      "integrity": "sha512-GMYHpzXeRwVXaHckrEbqqSNjNbms1oRSntP2weG4mrUMWAoLgF4b0ag/qqpYRbDEBfbC3Njt3+R5nX3lbP0Lww=="
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  },
+  "dependencies": {
+    "abbrev": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+      "dev": true
+    },
+    "acorn": {
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "^3.0.4"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+        }
+      }
+    },
+    "ajv": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "requires": {
+        "co": "^4.6.0",
+        "json-stable-stringify": "^1.0.1"
+      }
+    },
+    "ajv-keywords": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "requires": {}
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true,
+      "optional": true
+    },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "^0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
+    "cli-color": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.1.7.tgz",
+      "integrity": "sha1-rcMgD6RxzCEbDaf1ZrcemLnWc0c=",
+      "dev": true,
+      "requires": {
+        "es5-ext": "0.8.x"
+      },
+      "dependencies": {
+        "es5-ext": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.8.2.tgz",
+          "integrity": "sha1-q6jZ4ZQ6iVrJaDemKjmz9V7NlKs=",
           "dev": true
-        },
-        "file-entry-cache": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
-          "integrity": "sha1-mlhgcsaTZafvfscqfCuQRt4JHpw=",
-          "dev": true,
-          "requires": {
-            "flat-cache": "^1.0.9",
-            "object-assign": "^4.0.1"
-          },
-          "dependencies": {
-            "flat-cache": {
-              "version": "1.0.10",
-              "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.10.tgz",
-              "integrity": "sha1-c9bfSihQIWCgXgWVRKau6uiwBHo=",
-              "dev": true,
-              "requires": {
-                "del": "^2.0.2",
-                "graceful-fs": "^4.1.2",
-                "read-json-sync": "^1.1.0",
-                "write": "^0.2.1"
-              },
-              "dependencies": {
-                "del": {
-                  "version": "2.2.0",
-                  "resolved": "https://registry.npmjs.org/del/-/del-2.2.0.tgz",
-                  "integrity": "sha1-mlDwS/NzJeKDtPROmFM2wlJFa9U=",
-                  "dev": true,
-                  "requires": {
-                    "globby": "^4.0.0",
-                    "is-path-cwd": "^1.0.0",
-                    "is-path-in-cwd": "^1.0.0",
-                    "object-assign": "^4.0.1",
-                    "pify": "^2.0.0",
-                    "pinkie-promise": "^2.0.0",
-                    "rimraf": "^2.2.8"
-                  },
-                  "dependencies": {
-                    "globby": {
-                      "version": "4.0.0",
-                      "resolved": "https://registry.npmjs.org/globby/-/globby-4.0.0.tgz",
-                      "integrity": "sha1-Nv8GxancHbwgH3AAdJkogoV+mBc=",
-                      "dev": true,
-                      "requires": {
-                        "array-union": "^1.0.1",
-                        "arrify": "^1.0.0",
-                        "glob": "^6.0.1",
-                        "object-assign": "^4.0.1",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "array-union": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
-                          "integrity": "sha1-TUEPyDlcskdjcSS63p4/VH1dVfI=",
-                          "dev": true,
-                          "requires": {
-                            "array-uniq": "^1.0.1"
-                          },
-                          "dependencies": {
-                            "array-uniq": {
-                              "version": "1.0.2",
-                              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
-                              "integrity": "sha1-X8w3OSB3VyPP1k1lxkvvU7+eum0=",
-                              "dev": true
-                            }
-                          }
-                        },
-                        "arrify": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-                          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-                          "dev": true
-                        },
-                        "glob": {
-                          "version": "6.0.4",
-                          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-                          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-                          "dev": true,
-                          "requires": {
-                            "inflight": "^1.0.4",
-                            "inherits": "2",
-                            "minimatch": "2 || 3",
-                            "once": "^1.3.0",
-                            "path-is-absolute": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "inflight": {
-                              "version": "1.0.4",
-                              "resolved": "http://archive.local.uber.internal/npm/inflight/inflight-1.0.4.tgz",
-                              "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
-                              "dev": true,
-                              "requires": {
-                                "once": "^1.3.0",
-                                "wrappy": "1"
-                              },
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1",
-                                  "resolved": "http://archive.local.uber.internal/npm/wrappy/wrappy-1.0.1.tgz",
-                                  "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
-                                  "dev": true
-                                }
-                              }
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "resolved": "http://archive.local.uber.internal/npm/inherits/inherits-2.0.1.tgz",
-                              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-                              "dev": true
-                            },
-                            "minimatch": {
-                              "version": "3.0.0",
-                              "resolved": "http://archive.local.uber.internal/npm/minimatch/minimatch-3.0.0.tgz",
-                              "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
-                              "dev": true,
-                              "requires": {
-                                "brace-expansion": "^1.0.0"
-                              },
-                              "dependencies": {
-                                "brace-expansion": {
-                                  "version": "1.1.3",
-                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                                  "integrity": "sha1-Rr/1ARXUf8mriYVKu4fZgHihCZE=",
-                                  "dev": true,
-                                  "requires": {
-                                    "balanced-match": "^0.3.0",
-                                    "concat-map": "0.0.1"
-                                  },
-                                  "dependencies": {
-                                    "balanced-match": {
-                                      "version": "0.3.0",
-                                      "resolved": "http://archive.local.uber.internal/npm/balanced-match/balanced-match-0.3.0.tgz",
-                                      "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y=",
-                                      "dev": true
-                                    },
-                                    "concat-map": {
-                                      "version": "0.0.1",
-                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                                      "dev": true
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "once": {
-                              "version": "1.3.3",
-                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                              "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-                              "dev": true,
-                              "requires": {
-                                "wrappy": "1"
-                              },
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1",
-                                  "resolved": "http://archive.local.uber.internal/npm/wrappy/wrappy-1.0.1.tgz",
-                                  "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
-                                  "dev": true
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "is-path-cwd": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-                      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-                      "dev": true
-                    },
-                    "is-path-in-cwd": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-                      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-                      "dev": true,
-                      "requires": {
-                        "is-path-inside": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "is-path-inside": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-                          "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-                          "dev": true,
-                          "requires": {
-                            "path-is-inside": "^1.0.1"
-                          }
-                        }
-                      }
-                    },
-                    "pify": {
-                      "version": "2.3.0",
-                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                      "dev": true
-                    },
-                    "pinkie-promise": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-                      "dev": true,
-                      "requires": {
-                        "pinkie": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "pinkie": {
-                          "version": "2.0.4",
-                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "rimraf": {
-                      "version": "2.5.2",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
-                      "integrity": "sha1-YrqUf6TAtDY4Oa7+zU8PutYFlyY=",
-                      "dev": true,
-                      "requires": {
-                        "glob": "^7.0.0"
-                      }
-                    }
-                  }
-                },
-                "graceful-fs": {
-                  "version": "4.1.3",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-                  "integrity": "sha1-kgM84RETxB4mKNYf36QLwQ3AFVw=",
-                  "dev": true
-                },
-                "read-json-sync": {
-                  "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.1.tgz",
-                  "integrity": "sha1-Q8ZproZKrjCN+7snIaZ+KV7I//Y=",
-                  "dev": true,
-                  "requires": {
-                    "graceful-fs": "^4.1.2"
-                  }
-                },
-                "write": {
-                  "version": "0.2.1",
-                  "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-                  "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-                  "dev": true,
-                  "requires": {
-                    "mkdirp": "^0.5.1"
-                  }
-                }
-              }
-            },
-            "object-assign": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
-              "integrity": "sha1-mVBEVsNZi1ytT8WcJuipuxB/4L0=",
-              "dev": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
-          "integrity": "sha1-CqI1kxpKlqwT1g/6wvuHe9btT1g=",
-          "dev": true,
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          },
-          "dependencies": {
-            "inflight": {
-              "version": "1.0.4",
-              "resolved": "http://archive.local.uber.internal/npm/inflight/inflight-1.0.4.tgz",
-              "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
-              "dev": true,
-              "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-              },
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "resolved": "http://archive.local.uber.internal/npm/wrappy/wrappy-1.0.1.tgz",
-                  "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
-                  "dev": true
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "resolved": "http://archive.local.uber.internal/npm/inherits/inherits-2.0.1.tgz",
-              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-              "dev": true
-            },
-            "minimatch": {
-              "version": "3.0.0",
-              "resolved": "http://archive.local.uber.internal/npm/minimatch/minimatch-3.0.0.tgz",
-              "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
-              "dev": true,
-              "requires": {
-                "brace-expansion": "^1.0.0"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                  "integrity": "sha1-Rr/1ARXUf8mriYVKu4fZgHihCZE=",
-                  "dev": true,
-                  "requires": {
-                    "balanced-match": "^0.3.0",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0",
-                      "resolved": "http://archive.local.uber.internal/npm/balanced-match/balanced-match-0.3.0.tgz",
-                      "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y=",
-                      "dev": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.3.3",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-              "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-              "dev": true,
-              "requires": {
-                "wrappy": "1"
-              },
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "resolved": "http://archive.local.uber.internal/npm/wrappy/wrappy-1.0.1.tgz",
-                  "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "globals": {
-          "version": "9.4.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.4.0.tgz",
-          "integrity": "sha1-6JkGu9WLQDBeVpHvk0Mk6TMls18=",
-          "dev": true
-        },
-        "ignore": {
+        }
+      }
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^1.0.1"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dev": true,
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "difflib": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz",
+      "integrity": "sha1-teMDYabbAjF21WKJLbhZQKcY9H4=",
+      "dev": true,
+      "requires": {
+        "heap": ">= 0.2.0"
+      }
+    },
+    "doctrine": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+      "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "isarray": "^1.0.0"
+      }
+    },
+    "dreamopt": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.6.0.tgz",
+      "integrity": "sha1-2BPM2sjTnYrVJndVFKE92mZNa0s=",
+      "dev": true,
+      "requires": {
+        "wordwrap": ">=0.0.2"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-map": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
+      }
+    },
+    "es6-set": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "~0.3.5"
+      },
+      "dependencies": {
+        "es6-symbol": {
           "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.1.1.tgz",
-          "integrity": "sha1-CelBxSDGFFKo7BJ/5wtLbk8oHN4=",
-          "dev": true
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-          "dev": true
-        },
-        "inquirer": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-          "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
           "dev": true,
           "requires": {
-            "ansi-escapes": "^1.1.0",
-            "ansi-regex": "^2.0.0",
-            "chalk": "^1.0.0",
-            "cli-cursor": "^1.0.1",
-            "cli-width": "^2.0.0",
-            "figures": "^1.3.5",
-            "lodash": "^4.3.0",
-            "readline2": "^1.0.1",
-            "run-async": "^0.1.0",
-            "rx-lite": "^3.1.2",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.0",
-            "through": "^2.3.6"
-          },
-          "dependencies": {
-            "ansi-escapes": {
-              "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.3.0.tgz",
-              "integrity": "sha1-BwiDwzfV5M6eEk/OJjkmfyoU1VQ=",
-              "dev": true
-            },
-            "ansi-regex": {
-              "version": "2.0.0",
-              "resolved": "http://archive.local.uber.internal/npm/ansi-regex/ansi-regex-2.0.0.tgz",
-              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
-              "dev": true
-            },
-            "cli-cursor": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-              "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-              "dev": true,
-              "requires": {
-                "restore-cursor": "^1.0.1"
-              },
-              "dependencies": {
-                "restore-cursor": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-                  "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-                  "dev": true,
-                  "requires": {
-                    "exit-hook": "^1.0.0",
-                    "onetime": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "exit-hook": {
-                      "version": "1.1.1",
-                      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-                      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
-                      "dev": true
-                    },
-                    "onetime": {
-                      "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-                      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "cli-width": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-              "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
-              "dev": true
-            },
-            "figures": {
-              "version": "1.5.0",
-              "resolved": "https://registry.npmjs.org/figures/-/figures-1.5.0.tgz",
-              "integrity": "sha1-VtiglJwZZDr3ZNVzpkjThCGNpzc=",
-              "dev": true
-            },
-            "readline2": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-              "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "mute-stream": "0.0.5"
-              },
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-                  "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
-                  "dev": true,
-                  "requires": {
-                    "number-is-nan": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
-                      "dev": true
-                    }
-                  }
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                  "dev": true,
-                  "requires": {
-                    "number-is-nan": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
-                      "dev": true
-                    }
-                  }
-                },
-                "mute-stream": {
-                  "version": "0.0.5",
-                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-                  "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
-                  "dev": true
-                }
-              }
-            },
-            "run-async": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-              "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-              "dev": true,
-              "requires": {
-                "once": "^1.3.0"
-              },
-              "dependencies": {
-                "once": {
-                  "version": "1.3.3",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-                  "dev": true,
-                  "requires": {
-                    "wrappy": "1"
-                  },
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "resolved": "http://archive.local.uber.internal/npm/wrappy/wrappy-1.0.1.tgz",
-                      "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "rx-lite": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-              "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
-              "dev": true
-            },
-            "string-width": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
-              "integrity": "sha1-ySEptvHX9SrPmvQkom44ZKBc6wo=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              },
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-                  "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
-                  "dev": true,
-                  "requires": {
-                    "number-is-nan": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
-                      "dev": true
-                    }
-                  }
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                  "dev": true,
-                  "requires": {
-                    "number-is-nan": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            },
-            "through": {
-              "version": "2.3.8",
-              "resolved": "http://archive.local.uber.internal/npm/through/through-2.3.8.tgz",
-              "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-              "dev": true
-            }
-          }
-        },
-        "is-my-json-valid": {
-          "version": "2.13.1",
-          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
-          "integrity": "sha1-1Vd4qC/rawlj/0vhEdXRaE6JBwc=",
-          "dev": true,
-          "requires": {
-            "generate-function": "^2.0.0",
-            "generate-object-property": "^1.1.0",
-            "jsonpointer": "2.0.0",
-            "xtend": "^4.0.0"
-          },
-          "dependencies": {
-            "generate-function": {
-              "version": "2.0.0",
-              "resolved": "http://archive.local.uber.internal/npm/generate-function/generate-function-2.0.0.tgz",
-              "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-              "dev": true
-            },
-            "generate-object-property": {
-              "version": "1.2.0",
-              "resolved": "http://archive.local.uber.internal/npm/generate-object-property/generate-object-property-1.2.0.tgz",
-              "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-              "dev": true,
-              "requires": {
-                "is-property": "^1.0.0"
-              },
-              "dependencies": {
-                "is-property": {
-                  "version": "1.0.2",
-                  "resolved": "http://archive.local.uber.internal/npm/is-property/is-property-1.0.2.tgz",
-                  "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-                  "dev": true
-                }
-              }
-            },
-            "jsonpointer": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-              "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk=",
-              "dev": true
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "resolved": "http://archive.local.uber.internal/npm/xtend/xtend-4.0.1.tgz",
-              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-              "dev": true
-            }
-          }
-        },
-        "is-resolvable": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-          "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-          "dev": true,
-          "requires": {
-            "tryit": "^1.0.1"
-          },
-          "dependencies": {
-            "tryit": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.2.tgz",
-              "integrity": "sha1-wZawBz5rHFldk8nIMIVbeswypFM=",
-              "dev": true
-            }
-          }
-        },
-        "js-yaml": {
-          "version": "3.5.5",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
-          "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.2",
-            "esprima": "^2.6.0"
-          },
-          "dependencies": {
-            "argparse": {
-              "version": "1.0.7",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
-              "integrity": "sha1-wolQZIBVeBDxSovGLXoG9j7X+VE=",
-              "dev": true,
-              "requires": {
-                "sprintf-js": "~1.0.2"
-              },
-              "dependencies": {
-                "sprintf-js": {
-                  "version": "1.0.3",
-                  "resolved": "http://archive.local.uber.internal/npm/sprintf-js/sprintf-js-1.0.3.tgz",
-                  "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-                  "dev": true
-                }
-              }
-            },
-            "esprima": {
-              "version": "2.7.2",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
-              "integrity": "sha1-9DvlQ2CZhOrkTJM6xjNSpq818zk=",
-              "dev": true
-            }
-          }
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-          "dev": true,
-          "requires": {
-            "jsonify": "~0.0.0"
-          },
-          "dependencies": {
-            "jsonify": {
-              "version": "0.0.0",
-              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-              "dev": true
-            }
-          }
-        },
-        "lodash": {
-          "version": "4.9.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.9.0.tgz",
-          "integrity": "sha1-TCDXQvA86F3HAODderm8q4Xm/BQ=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "http://archive.local.uber.internal/npm/mkdirp/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "dev": true
-            }
-          }
-        },
-        "optionator": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
-          "integrity": "sha1-4xtJMs3V+4Yqiw0QvGPT7h7H14s=",
-          "dev": true,
-          "requires": {
-            "deep-is": "~0.1.3",
-            "fast-levenshtein": "^1.1.0",
-            "levn": "~0.3.0",
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2",
-            "wordwrap": "~1.0.0"
-          },
-          "dependencies": {
-            "deep-is": {
-              "version": "0.1.3",
-              "resolved": "http://archive.local.uber.internal/npm/deep-is/deep-is-0.1.3.tgz",
-              "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-              "dev": true
-            },
-            "fast-levenshtein": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz",
-              "integrity": "sha1-KuezKrweYS2kik4ThJuIii9h5+k=",
-              "dev": true
-            },
-            "levn": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-              "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-              "dev": true,
-              "requires": {
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2"
-              }
-            },
-            "prelude-ls": {
-              "version": "1.1.2",
-              "resolved": "http://archive.local.uber.internal/npm/prelude-ls/prelude-ls-1.1.2.tgz",
-              "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-              "dev": true
-            },
-            "type-check": {
-              "version": "0.3.2",
-              "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-              "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-              "dev": true,
-              "requires": {
-                "prelude-ls": "~1.1.2"
-              }
-            },
-            "wordwrap": {
-              "version": "1.0.0",
-              "resolved": "http://archive.local.uber.internal/npm/wordwrap/wordwrap-1.0.0.tgz",
-              "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-              "dev": true
-            }
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.0",
-          "resolved": "http://archive.local.uber.internal/npm/path-is-absolute/path-is-absolute-1.0.0.tgz",
-          "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
-          "dev": true
-        },
-        "path-is-inside": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
-          "integrity": "sha1-mNjx0DC/BL167uShulSF1AMY/Yk=",
-          "dev": true
-        },
-        "pluralize": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-          "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
-          "dev": true
-        },
-        "progress": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
-          "dev": true
-        },
-        "require-uncached": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.2.tgz",
-          "integrity": "sha1-Z9rTtzMInncDASRnikWVifr2p+w=",
-          "dev": true,
-          "requires": {
-            "caller-path": "^0.1.0",
-            "resolve-from": "^1.0.0"
-          },
-          "dependencies": {
-            "caller-path": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-              "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-              "dev": true,
-              "requires": {
-                "callsites": "^0.2.0"
-              },
-              "dependencies": {
-                "callsites": {
-                  "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-                  "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-                  "dev": true
-                }
-              }
-            },
-            "resolve-from": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-              "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-              "dev": true
-            }
-          }
-        },
-        "shelljs": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.0.tgz",
-          "integrity": "sha1-zh7YN7Sw5Vtew9q4QlGrnb3Ax+w=",
-          "dev": true
-        },
-        "strip-json-comments": {
-          "version": "1.0.4",
-          "resolved": "http://archive.local.uber.internal/npm/strip-json-comments/strip-json-comments-1.0.4.tgz",
-          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
-          "dev": true
-        },
-        "table": {
-          "version": "3.7.8",
-          "resolved": "https://registry.npmjs.org/table/-/table-3.7.8.tgz",
-          "integrity": "sha1-tCRDPvWWhRkisv13IkppoZUWGOs=",
-          "dev": true,
-          "requires": {
-            "bluebird": "^3.1.1",
-            "chalk": "^1.1.1",
-            "lodash": "^4.0.0",
-            "slice-ansi": "0.0.4",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.0",
-            "tv4": "^1.2.7",
-            "xregexp": "^3.0.0"
-          },
-          "dependencies": {
-            "bluebird": {
-              "version": "3.3.4",
-              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.4.tgz",
-              "integrity": "sha1-94D+Q+GnplEPZ6vX0NeVM6QN3eY=",
-              "dev": true
-            },
-            "slice-ansi": {
-              "version": "0.0.4",
-              "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-              "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-              "dev": true
-            },
-            "string-width": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
-              "integrity": "sha1-ySEptvHX9SrPmvQkom44ZKBc6wo=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              },
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-                  "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
-                  "dev": true,
-                  "requires": {
-                    "number-is-nan": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
-                      "dev": true
-                    }
-                  }
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                  "dev": true,
-                  "requires": {
-                    "number-is-nan": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "resolved": "http://archive.local.uber.internal/npm/ansi-regex/ansi-regex-2.0.0.tgz",
-                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
-                  "dev": true
-                }
-              }
-            },
-            "tv4": {
-              "version": "1.2.7",
-              "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.2.7.tgz",
-              "integrity": "sha1-vSk4mvxzreSa5fSBQrXVRL9o0SA=",
-              "dev": true
-            },
-            "xregexp": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-3.1.0.tgz",
-              "integrity": "sha1-FNhGHgvdOCJL/uUDmgiY/EL80zY=",
-              "dev": true
-            }
-          }
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "resolved": "http://archive.local.uber.internal/npm/text-table/text-table-0.2.0.tgz",
-          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-          "dev": true
-        },
-        "user-home": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-          "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-          "dev": true,
-          "requires": {
-            "os-homedir": "^1.0.0"
-          },
-          "dependencies": {
-            "os-homedir": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-              "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac=",
-              "dev": true
-            }
+            "d": "1",
+            "es5-ext": "~0.10.14"
           }
         }
       }
     },
+    "es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "dev": true,
+      "requires": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "escodegen": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+      "dev": true,
+      "requires": {
+        "esprima": "^2.7.1",
+        "estraverse": "^1.9.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+          "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+          "dev": true
+        }
+      }
+    },
+    "escope": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "dev": true,
+      "requires": {
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
+      "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "concat-stream": "^1.4.6",
+        "debug": "^2.1.1",
+        "doctrine": "^1.2.2",
+        "es6-map": "^0.1.3",
+        "escope": "^3.6.0",
+        "espree": "^3.1.6",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^1.1.1",
+        "glob": "^7.0.3",
+        "globals": "^9.2.0",
+        "ignore": "^3.1.2",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^0.12.0",
+        "is-my-json-valid": "^2.10.0",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.5.1",
+        "json-stable-stringify": "^1.0.0",
+        "levn": "^0.3.0",
+        "lodash": "^4.0.0",
+        "mkdirp": "^0.5.0",
+        "optionator": "^0.8.1",
+        "path-is-absolute": "^1.0.0",
+        "path-is-inside": "^1.0.1",
+        "pluralize": "^1.2.1",
+        "progress": "^1.1.8",
+        "require-uncached": "^1.0.2",
+        "shelljs": "^0.6.0",
+        "strip-json-comments": "~1.0.1",
+        "table": "^3.7.8",
+        "text-table": "~0.2.0",
+        "user-home": "^2.0.0"
+      }
+    },
+    "espree": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
+      }
+    },
+    "esprima": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "dev": true
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true
+    },
+    "ext": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "dev": true,
+      "requires": {
+        "type": "^2.0.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.3.0.tgz",
+          "integrity": "sha512-rgPIqOdfK/4J9FhiVrZ3cveAjRRo5rsQBAIhnylX874y1DX/kEKSVdLsnuHB6l1KTjHyU01VjiMBHgU2adejyg==",
+          "dev": true
+        }
+      }
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
+      }
+    },
+    "file-entry-cache": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
+      "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+      "dev": true,
+      "requires": {
+        "circular-json": "^0.3.1",
+        "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
+        "write": "^0.2.1"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
+      "requires": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "requires": {
+        "is-property": "^1.0.0"
+      }
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true
+    },
+    "graceful-fs": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "dev": true
+    },
+    "handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "heap": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
+      "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw=",
+      "dev": true
+    },
+    "ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^1.1.0",
+        "ansi-regex": "^2.0.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "figures": "^1.3.5",
+        "lodash": "^4.3.0",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^3.1.2",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "dev": true
+    },
+    "is-my-json-valid": {
+      "version": "2.20.5",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.5.tgz",
+      "integrity": "sha512-VTPuvvGQtxvCeghwspQu1rBgjYUT6FGxPlvFKbYuFtgc4ADsX3U5ihZOYN0qyU6u+d4X9xXb0IT5O6QpXKt87A==",
+      "dev": true,
+      "requires": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
     "istanbul": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.3.tgz",
-      "integrity": "sha1-W3FO4K5JOsXvIEuZ84crzu9z1To=",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
       "requires": {
         "abbrev": "1.0.x",
         "async": "1.x",
         "escodegen": "1.8.x",
         "esprima": "2.7.x",
-        "fileset": "0.2.x",
+        "glob": "^5.0.15",
         "handlebars": "^4.0.1",
         "js-yaml": "3.x",
         "mkdirp": "0.5.x",
@@ -1476,695 +2438,224 @@
         "wordwrap": "^1.0.0"
       },
       "dependencies": {
-        "abbrev": {
-          "version": "1.0.7",
-          "resolved": "http://archive.local.uber.internal/npm/abbrev/abbrev-1.0.7.tgz",
-          "integrity": "sha1-W2A1su6dT7XPhZ8Iqb6BsghJGEM=",
-          "dev": true
-        },
-        "async": {
-          "version": "1.5.2",
-          "resolved": "http://archive.local.uber.internal/npm/async/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        },
-        "escodegen": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.0.tgz",
-          "integrity": "sha1-skaq6CnOc9WeLFVyc1nt0cEwqBs=",
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "esprima": "^2.7.1",
-            "estraverse": "^1.9.1",
-            "esutils": "^2.0.2",
-            "optionator": "^0.8.1",
-            "source-map": "~0.2.0"
-          },
-          "dependencies": {
-            "estraverse": {
-              "version": "1.9.3",
-              "resolved": "http://archive.local.uber.internal/npm/estraverse/estraverse-1.9.3.tgz",
-              "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
-              "dev": true
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-              "dev": true
-            },
-            "optionator": {
-              "version": "0.8.1",
-              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
-              "integrity": "sha1-4xtJMs3V+4Yqiw0QvGPT7h7H14s=",
-              "dev": true,
-              "requires": {
-                "deep-is": "~0.1.3",
-                "fast-levenshtein": "^1.1.0",
-                "levn": "~0.3.0",
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2",
-                "wordwrap": "~1.0.0"
-              },
-              "dependencies": {
-                "deep-is": {
-                  "version": "0.1.3",
-                  "resolved": "http://archive.local.uber.internal/npm/deep-is/deep-is-0.1.3.tgz",
-                  "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-                  "dev": true
-                },
-                "fast-levenshtein": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz",
-                  "integrity": "sha1-KuezKrweYS2kik4ThJuIii9h5+k=",
-                  "dev": true
-                },
-                "levn": {
-                  "version": "0.3.0",
-                  "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-                  "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-                  "dev": true,
-                  "requires": {
-                    "prelude-ls": "~1.1.2",
-                    "type-check": "~0.3.2"
-                  }
-                },
-                "prelude-ls": {
-                  "version": "1.1.2",
-                  "resolved": "http://archive.local.uber.internal/npm/prelude-ls/prelude-ls-1.1.2.tgz",
-                  "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-                  "dev": true
-                },
-                "type-check": {
-                  "version": "0.3.2",
-                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-                  "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-                  "dev": true,
-                  "requires": {
-                    "prelude-ls": "~1.1.2"
-                  }
-                }
-              }
-            },
-            "source-map": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-              "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "amdefine": ">=0.0.4"
-              },
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0",
-                  "resolved": "http://archive.local.uber.internal/npm/amdefine/amdefine-1.0.0.tgz",
-                  "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
-                  "dev": true,
-                  "optional": true
-                }
-              }
-            }
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
-        },
-        "esprima": {
-          "version": "2.7.2",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
-          "integrity": "sha1-9DvlQ2CZhOrkTJM6xjNSpq818zk=",
-          "dev": true
-        },
-        "fileset": {
-          "version": "0.2.1",
-          "resolved": "http://archive.local.uber.internal/npm/fileset/fileset-0.2.1.tgz",
-          "integrity": "sha1-WI74lzxmI7KnbfRlEFaWuWqsgGc=",
-          "dev": true,
-          "requires": {
-            "glob": "5.x",
-            "minimatch": "2.x"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "5.0.15",
-              "resolved": "http://archive.local.uber.internal/npm/glob/glob-5.0.15.tgz",
-              "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-              "dev": true,
-              "requires": {
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "2 || 3",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              },
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "resolved": "http://archive.local.uber.internal/npm/inflight/inflight-1.0.4.tgz",
-                  "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
-                  "dev": true,
-                  "requires": {
-                    "once": "^1.3.0",
-                    "wrappy": "1"
-                  },
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "resolved": "http://archive.local.uber.internal/npm/wrappy/wrappy-1.0.1.tgz",
-                      "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
-                      "dev": true
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "http://archive.local.uber.internal/npm/inherits/inherits-2.0.1.tgz",
-                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-                  "dev": true
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "resolved": "http://archive.local.uber.internal/npm/path-is-absolute/path-is-absolute-1.0.0.tgz",
-                  "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
-                  "dev": true
-                }
-              }
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "resolved": "http://archive.local.uber.internal/npm/minimatch/minimatch-2.0.10.tgz",
-              "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-              "dev": true,
-              "requires": {
-                "brace-expansion": "^1.0.0"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                  "integrity": "sha1-Rr/1ARXUf8mriYVKu4fZgHihCZE=",
-                  "dev": true,
-                  "requires": {
-                    "balanced-match": "^0.3.0",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0",
-                      "resolved": "http://archive.local.uber.internal/npm/balanced-match/balanced-match-0.3.0.tgz",
-                      "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y=",
-                      "dev": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "handlebars": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
-          "integrity": "sha1-ksbta7FkEQxQ1NjQ+93HCAbG+Oc=",
-          "dev": true,
-          "requires": {
-            "async": "^1.4.0",
-            "optimist": "^0.6.1",
-            "source-map": "^0.4.4",
-            "uglify-js": "^2.6"
-          },
-          "dependencies": {
-            "optimist": {
-              "version": "0.6.1",
-              "resolved": "http://archive.local.uber.internal/npm/optimist/optimist-0.6.1.tgz",
-              "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-              "dev": true,
-              "requires": {
-                "minimist": "~0.0.1",
-                "wordwrap": "~0.0.2"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.10",
-                  "resolved": "http://archive.local.uber.internal/npm/minimist/minimist-0.0.10.tgz",
-                  "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-                  "dev": true
-                },
-                "wordwrap": {
-                  "version": "0.0.3",
-                  "resolved": "http://archive.local.uber.internal/npm/wordwrap/wordwrap-0.0.3.tgz",
-                  "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-                  "dev": true
-                }
-              }
-            },
-            "source-map": {
-              "version": "0.4.4",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-              "dev": true,
-              "requires": {
-                "amdefine": ">=0.0.4"
-              },
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0",
-                  "resolved": "http://archive.local.uber.internal/npm/amdefine/amdefine-1.0.0.tgz",
-                  "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
-                  "dev": true
-                }
-              }
-            },
-            "uglify-js": {
-              "version": "2.6.2",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
-              "integrity": "sha1-9QvoikLNOWpiUdxSqzcvccwS/vA=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "async": "~0.2.6",
-                "source-map": "~0.5.1",
-                "uglify-to-browserify": "~1.0.0",
-                "yargs": "~3.10.0"
-              },
-              "dependencies": {
-                "async": {
-                  "version": "0.2.10",
-                  "resolved": "http://archive.local.uber.internal/npm/async/async-0.2.10.tgz",
-                  "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-                  "dev": true,
-                  "optional": true
-                },
-                "source-map": {
-                  "version": "0.5.3",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-                  "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A=",
-                  "dev": true,
-                  "optional": true
-                },
-                "uglify-to-browserify": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-                  "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-                  "dev": true,
-                  "optional": true
-                },
-                "yargs": {
-                  "version": "3.10.0",
-                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-                  "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "camelcase": "^1.0.2",
-                    "cliui": "^2.1.0",
-                    "decamelize": "^1.0.0",
-                    "window-size": "0.1.0"
-                  },
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "1.2.1",
-                      "resolved": "http://archive.local.uber.internal/npm/camelcase/camelcase-1.2.1.tgz",
-                      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-                      "dev": true,
-                      "optional": true
-                    },
-                    "cliui": {
-                      "version": "2.1.0",
-                      "resolved": "http://archive.local.uber.internal/npm/cliui/cliui-2.1.0.tgz",
-                      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-                      "dev": true,
-                      "optional": true,
-                      "requires": {
-                        "center-align": "^0.1.1",
-                        "right-align": "^0.1.1",
-                        "wordwrap": "0.0.2"
-                      },
-                      "dependencies": {
-                        "center-align": {
-                          "version": "0.1.3",
-                          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-                          "dev": true,
-                          "optional": true,
-                          "requires": {
-                            "align-text": "^0.1.3",
-                            "lazy-cache": "^1.0.3"
-                          },
-                          "dependencies": {
-                            "align-text": {
-                              "version": "0.1.4",
-                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                              "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-                              "dev": true,
-                              "optional": true,
-                              "requires": {
-                                "kind-of": "^3.0.2",
-                                "longest": "^1.0.1",
-                                "repeat-string": "^1.5.2"
-                              },
-                              "dependencies": {
-                                "kind-of": {
-                                  "version": "3.0.2",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-                                  "integrity": "sha1-GH20JwRufpCUVpLmdoZovWkA3qA=",
-                                  "dev": true,
-                                  "optional": true,
-                                  "requires": {
-                                    "is-buffer": "^1.0.2"
-                                  },
-                                  "dependencies": {
-                                    "is-buffer": {
-                                      "version": "1.1.3",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
-                                      "integrity": "sha1-24l/w/esotUN6UtsjCiWpHcWJ68=",
-                                      "dev": true,
-                                      "optional": true
-                                    }
-                                  }
-                                },
-                                "longest": {
-                                  "version": "1.0.1",
-                                  "resolved": "http://archive.local.uber.internal/npm/longest/longest-1.0.1.tgz",
-                                  "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-                                  "dev": true,
-                                  "optional": true
-                                },
-                                "repeat-string": {
-                                  "version": "1.5.4",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-                                  "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
-                                  "dev": true,
-                                  "optional": true
-                                }
-                              }
-                            },
-                            "lazy-cache": {
-                              "version": "1.0.3",
-                              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
-                              "integrity": "sha1-6XdUYY+ciGu5mbL/aceLgkU9ZnQ=",
-                              "dev": true,
-                              "optional": true
-                            }
-                          }
-                        },
-                        "right-align": {
-                          "version": "0.1.3",
-                          "resolved": "http://archive.local.uber.internal/npm/right-align/right-align-0.1.3.tgz",
-                          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-                          "dev": true,
-                          "optional": true,
-                          "requires": {
-                            "align-text": "^0.1.1"
-                          },
-                          "dependencies": {
-                            "align-text": {
-                              "version": "0.1.4",
-                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                              "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-                              "dev": true,
-                              "optional": true,
-                              "requires": {
-                                "kind-of": "^3.0.2",
-                                "longest": "^1.0.1",
-                                "repeat-string": "^1.5.2"
-                              },
-                              "dependencies": {
-                                "kind-of": {
-                                  "version": "3.0.2",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-                                  "integrity": "sha1-GH20JwRufpCUVpLmdoZovWkA3qA=",
-                                  "dev": true,
-                                  "optional": true,
-                                  "requires": {
-                                    "is-buffer": "^1.0.2"
-                                  },
-                                  "dependencies": {
-                                    "is-buffer": {
-                                      "version": "1.1.3",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
-                                      "integrity": "sha1-24l/w/esotUN6UtsjCiWpHcWJ68=",
-                                      "dev": true,
-                                      "optional": true
-                                    }
-                                  }
-                                },
-                                "longest": {
-                                  "version": "1.0.1",
-                                  "resolved": "http://archive.local.uber.internal/npm/longest/longest-1.0.1.tgz",
-                                  "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-                                  "dev": true,
-                                  "optional": true
-                                },
-                                "repeat-string": {
-                                  "version": "1.5.4",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-                                  "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
-                                  "dev": true,
-                                  "optional": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "wordwrap": {
-                          "version": "0.0.2",
-                          "resolved": "http://archive.local.uber.internal/npm/wordwrap/wordwrap-0.0.2.tgz",
-                          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-                          "dev": true,
-                          "optional": true
-                        }
-                      }
-                    },
-                    "decamelize": {
-                      "version": "1.2.0",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-                      "dev": true,
-                      "optional": true
-                    },
-                    "window-size": {
-                      "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-                      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-                      "dev": true,
-                      "optional": true
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "js-yaml": {
-          "version": "3.5.5",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
-          "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.2",
-            "esprima": "^2.6.0"
-          },
-          "dependencies": {
-            "argparse": {
-              "version": "1.0.7",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
-              "integrity": "sha1-wolQZIBVeBDxSovGLXoG9j7X+VE=",
-              "dev": true,
-              "requires": {
-                "sprintf-js": "~1.0.2"
-              },
-              "dependencies": {
-                "sprintf-js": {
-                  "version": "1.0.3",
-                  "resolved": "http://archive.local.uber.internal/npm/sprintf-js/sprintf-js-1.0.3.tgz",
-                  "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "http://archive.local.uber.internal/npm/mkdirp/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "dev": true
-            }
-          }
-        },
-        "nopt": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true,
-          "requires": {
-            "abbrev": "1"
-          }
-        },
-        "once": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1"
-          },
-          "dependencies": {
-            "wrappy": {
-              "version": "1.0.1",
-              "resolved": "http://archive.local.uber.internal/npm/wrappy/wrappy-1.0.1.tgz",
-              "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
-              "dev": true
-            }
-          }
-        },
-        "resolve": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
         },
         "supports-color": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
             "has-flag": "^1.0.0"
-          },
-          "dependencies": {
-            "has-flag": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-              "dev": true
-            }
           }
-        },
-        "which": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
-          "integrity": "sha1-FVf5YIBgTlsRs1meufRbUKnv1yI=",
-          "dev": true,
-          "requires": {
-            "is-absolute": "^0.1.7",
-            "isexe": "^1.1.1"
-          },
-          "dependencies": {
-            "is-absolute": {
-              "version": "0.1.7",
-              "resolved": "http://archive.local.uber.internal/npm/is-absolute/is-absolute-0.1.7.tgz",
-              "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
-              "dev": true,
-              "requires": {
-                "is-relative": "^0.1.0"
-              },
-              "dependencies": {
-                "is-relative": {
-                  "version": "0.1.3",
-                  "resolved": "http://archive.local.uber.internal/npm/is-relative/is-relative-0.1.3.tgz",
-                  "integrity": "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI=",
-                  "dev": true
-                }
-              }
-            },
-            "isexe": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-              "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
-              "dev": true
-            }
-          }
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "resolved": "http://archive.local.uber.internal/npm/wordwrap/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+        }
+      }
+    },
+    "js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
           "dev": true
         }
       }
     },
     "json-diff": {
       "version": "0.3.1",
-      "resolved": "http://archive.local.uber.internal/npm/json-diff/json-diff-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-diff/-/json-diff-0.3.1.tgz",
       "integrity": "sha1-bbw64tJeB1p/1xvNmHRFhmb7aBs=",
       "dev": true,
       "requires": {
         "cli-color": "~0.1.6",
         "difflib": "~0.2.1",
         "dreamopt": "~0.6.0"
-      },
-      "dependencies": {
-        "cli-color": {
-          "version": "0.1.7",
-          "resolved": "http://archive.local.uber.internal/npm/cli-color/cli-color-0.1.7.tgz",
-          "integrity": "sha1-rcMgD6RxzCEbDaf1ZrcemLnWc0c=",
-          "dev": true,
-          "requires": {
-            "es5-ext": "0.8.x"
-          },
-          "dependencies": {
-            "es5-ext": {
-              "version": "0.8.2",
-              "resolved": "http://archive.local.uber.internal/npm/es5-ext/es5-ext-0.8.2.tgz",
-              "integrity": "sha1-q6jZ4ZQ6iVrJaDemKjmz9V7NlKs=",
-              "dev": true
-            }
-          }
-        },
-        "difflib": {
-          "version": "0.2.4",
-          "resolved": "http://archive.local.uber.internal/npm/difflib/difflib-0.2.4.tgz",
-          "integrity": "sha1-teMDYabbAjF21WKJLbhZQKcY9H4=",
-          "dev": true,
-          "requires": {
-            "heap": ">= 0.2.0"
-          },
-          "dependencies": {
-            "heap": {
-              "version": "0.2.6",
-              "resolved": "http://archive.local.uber.internal/npm/heap/heap-0.2.6.tgz",
-              "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw=",
-              "dev": true
-            }
-          }
-        },
-        "dreamopt": {
-          "version": "0.6.0",
-          "resolved": "http://archive.local.uber.internal/npm/dreamopt/dreamopt-0.6.0.tgz",
-          "integrity": "sha1-2BPM2sjTnYrVJndVFKE92mZNa0s=",
-          "dev": true,
-          "requires": {
-            "wordwrap": ">=0.0.2"
-          },
-          "dependencies": {
-            "wordwrap": {
-              "version": "1.0.0",
-              "resolved": "http://archive.local.uber.internal/npm/wordwrap/wordwrap-1.0.0.tgz",
-              "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-              "dev": true
-            }
-          }
-        }
       }
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "jsonpointer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
+      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "mini-map": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mini-map/-/mini-map-1.0.0.tgz",
+      "integrity": "sha1-lkHgEV2Zs9wTcRz4z9pMgZmJP04="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "dev": true
+    },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
     },
     "opn": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz",
       "integrity": "sha1-uQlkM0bQChq8l3qLlvPOPFPVz18=",
+      "dev": true
+    },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "pluralize": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
       "dev": true
     },
     "pop-equals": {
@@ -2173,23 +2664,34 @@
       "integrity": "sha1-kEFPj9pxo3+IHR5eOi4C7ww7fgs=",
       "requires": {
         "mini-map": "^1.0.0"
-      },
-      "dependencies": {
-        "mini-map": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/mini-map/-/mini-map-1.0.0.tgz",
-          "integrity": "sha1-lkHgEV2Zs9wTcRz4z9pMgZmJP04="
-        }
       }
     },
     "pop-iterate": {
       "version": "1.0.1",
-      "resolved": "https://unpm.uberinternal.com/pop-iterate/-/pop-iterate-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pop-iterate/-/pop-iterate-1.0.1.tgz",
       "integrity": "sha1-zqz9q0q/NT16DyqqLB/Hs/lBO6M="
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "dev": true
     },
     "q": {
       "version": "2.0.3",
-      "resolved": "https://unpm.uberinternal.com/q/-/q-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/q/-/q-2.0.3.tgz",
       "integrity": "sha1-dbjbAlWhpa+C9Yw/Oqoe/sfQ0TQ=",
       "requires": {
         "asap": "^2.0.0",
@@ -2197,168 +2699,221 @@
         "weak-map": "^1.0.5"
       }
     },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "readline2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "mute-stream": "0.0.5"
+      }
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      }
+    },
+    "resolve": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+      "dev": true
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
+      "requires": {
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
+      }
+    },
     "rezult": {
       "version": "1.1.0",
-      "resolved": "https://unpm.uberinternal.com/rezult/-/rezult-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/rezult/-/rezult-1.1.0.tgz",
       "integrity": "sha1-Jymr+VQoe8+6feobp5qU+/8h+2s="
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "run-async": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0"
+      }
+    },
+    "rx-lite": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "shelljs": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
+      "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
+      "dev": true
     },
     "shon": {
       "version": "4.0.0",
-      "resolved": "https://unpm.uberinternal.com/shon/-/shon-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shon/-/shon-4.0.0.tgz",
       "integrity": "sha512-LNUpqq+iQCH9w/G7JeXUZO2NGg3FtsvmQwpUjzgE4czrsiH8GjEvVflhn7qWHgODydHW492YrSdc4QRCtvDzVQ==",
       "requires": {
         "camelcase": "^1.2.1",
         "rezult": "^1.1.0"
       }
     },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
+    },
+    "source-map": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+      "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "amdefine": ">=0.0.4"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
     "system": {
       "version": "1.3.0",
-      "resolved": "https://unpm.uberinternal.com/system/-/system-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/system/-/system-1.3.0.tgz",
       "integrity": "sha1-2ZR4vvsDzZ4v0vw0CyDNWrrRPfc=",
       "requires": {
         "q": "^2.0.3"
       }
     },
     "table": {
-      "version": "3.7.8",
-      "resolved": "https://registry.npmjs.org/table/-/table-3.7.8.tgz",
-      "integrity": "sha1-tCRDPvWWhRkisv13IkppoZUWGOs=",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "requires": {
-        "bluebird": "^3.1.1",
+        "ajv": "^4.7.0",
+        "ajv-keywords": "^1.0.0",
         "chalk": "^1.1.1",
         "lodash": "^4.0.0",
         "slice-ansi": "0.0.4",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.0",
-        "tv4": "^1.2.7",
-        "xregexp": "^3.0.0"
+        "string-width": "^2.0.0"
       },
       "dependencies": {
-        "bluebird": {
-          "version": "3.4.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.1.tgz",
-          "integrity": "sha1-tzHd9I4t077awudeEhWhG8uR+gc="
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "http://archive.local.uber.internal/npm/ansi-styles/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "http://archive.local.uber.internal/npm/escape-string-regexp/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "resolved": "http://archive.local.uber.internal/npm/has-ansi/has-ansi-2.0.0.tgz",
-              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "resolved": "http://archive.local.uber.internal/npm/ansi-regex/ansi-regex-2.0.0.tgz",
-                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "http://archive.local.uber.internal/npm/supports-color/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-            }
-          }
-        },
-        "lodash": {
-          "version": "4.13.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
-          "integrity": "sha1-g+SxCRP0hJbU0W/sSlYK8u50S2g="
-        },
-        "slice-ansi": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-          "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "string-width": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
-          "integrity": "sha1-ySEptvHX9SrPmvQkom44ZKBc6wo=",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          },
-          "dependencies": {
-            "code-point-at": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-              "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              },
-              "dependencies": {
-                "number-is-nan": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                  "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
-                }
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              },
-              "dependencies": {
-                "number-is-nan": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                  "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
-                }
-              }
-            }
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "^2.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.0.0",
-              "resolved": "http://archive.local.uber.internal/npm/ansi-regex/ansi-regex-2.0.0.tgz",
-              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
-            }
+            "ansi-regex": "^3.0.0"
           }
-        },
-        "tv4": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.2.7.tgz",
-          "integrity": "sha1-vSk4mvxzreSa5fSBQrXVRL9o0SA="
-        },
-        "xregexp": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-3.1.1.tgz",
-          "integrity": "sha1-juGNde9cfLP5ln+NKUFKbKWxoYQ="
         }
       }
     },
@@ -2377,15 +2932,112 @@
         }
       }
     },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "3.12.8",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.8.tgz",
+      "integrity": "sha512-fvBeuXOsvqjecUtF/l1dwsrrf5y2BCUk9AOJGzGcm6tE7vegku5u/YvqjyDaAGr422PLoLnrxg3EnRvTqsdC1w==",
+      "dev": true,
+      "optional": true
+    },
+    "user-home": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
     "weak-map": {
       "version": "1.0.5",
-      "resolved": "https://unpm.uberinternal.com/weak-map/-/weak-map-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.5.tgz",
       "integrity": "sha1-eWkVhNmGB/UHC9O3CkDmuyLkAes="
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     },
     "xorshift": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/xorshift/-/xorshift-1.1.1.tgz",
       "integrity": "sha512-GMYHpzXeRwVXaHckrEbqqSNjNbms1oRSntP2weG4mrUMWAoLgF4b0ag/qqpYRbDEBfbC3Njt3+R5nX3lbP0Lww=="
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "kni",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "4.0.2",
+      "version": "4.0.3",
       "license": "MIT",
       "dependencies": {
         "pop-equals": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kni",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "A text adventure language and runtime inspired by inkle/ink",
   "bin": {
     "kni": "./kni.js"


### PR DESCRIPTION
Based on v4.0.2, proposed minimal change to release v4.0.3, and then retcon the master/main branch shortly thereafter.